### PR TITLE
fix: v2.1.2 bugfixes — loading timeout, API key preservation, regression tests

### DIFF
--- a/com.felixgeelhaar.govee-light-management.sdPlugin/manifest.json
+++ b/com.felixgeelhaar.govee-light-management.sdPlugin/manifest.json
@@ -1,6 +1,6 @@
 {
   "Name": "Govee Light Management",
-  "Version": "2.1.1.0",
+  "Version": "2.1.2.0",
   "Author": "Felix Geelhaar",
   "URL": "https://github.com/felixgeelhaar/govee-light-management",
   "SupportURL": "https://github.com/felixgeelhaar/govee-light-management/issues",

--- a/com.felixgeelhaar.govee-light-management.sdPlugin/ui/js/setup.js
+++ b/com.felixgeelhaar.govee-light-management.sdPlugin/ui/js/setup.js
@@ -3,74 +3,122 @@
  * Handles: API key flow, conditional visibility, group management.
  */
 document.addEventListener("DOMContentLoaded", () => {
-	const setupWrapper = document.getElementById("setup");
-	const settingsWrapper = document.getElementById("settings");
-	const connectElem = document.getElementById("connect");
-	const apiKeyElem = document.getElementById("apiKey");
-	const failedElem = document.getElementById("errorMessage");
+  const setupWrapper = document.getElementById("setup");
+  const settingsWrapper = document.getElementById("settings");
+  const connectElem = document.getElementById("connect");
+  const apiKeyElem = document.getElementById("apiKey");
+  const failedElem = document.getElementById("errorMessage");
+  const API_KEY_PATTERN = /^[A-Za-z0-9-]{20,64}$/;
 
-	// Optional conditional visibility elements
-	const conditionalItems = {
-		brightness: document.getElementById("brightnessItem"),
-		color: document.getElementById("colorItem"),
-		colorTemp: document.getElementById("tempItem"),
-	};
-	const hasConditionalItems = Object.values(conditionalItems).some(Boolean);
+  // Optional conditional visibility elements
+  const conditionalItems = {
+    brightness: document.getElementById("brightnessItem"),
+    color: document.getElementById("colorItem"),
+    colorTemp: document.getElementById("tempItem"),
+  };
+  const hasConditionalItems = Object.values(conditionalItems).some(Boolean);
 
-	function showPanel(isSetup) {
-		if (isSetup) {
-			setupWrapper.classList.remove("hidden");
-			settingsWrapper.classList.add("hidden");
-		} else {
-			settingsWrapper.classList.remove("hidden");
-			setupWrapper.classList.add("hidden");
-		}
-	}
+  function showPanel(isSetup) {
+    if (isSetup) {
+      setupWrapper.classList.remove("hidden");
+      settingsWrapper.classList.add("hidden");
+    } else {
+      settingsWrapper.classList.remove("hidden");
+      setupWrapper.classList.add("hidden");
+    }
+  }
 
-	function updateConditionalVisibility(mode) {
-		if (!hasConditionalItems) return;
-		for (const [key, el] of Object.entries(conditionalItems)) {
-			if (el) el.style.display = key === mode ? "" : "none";
-		}
-	}
+  function updateConditionalVisibility(mode) {
+    if (!hasConditionalItems) return;
+    for (const [key, el] of Object.entries(conditionalItems)) {
+      if (el) el.style.display = key === mode ? "" : "none";
+    }
+  }
 
-	// ── API Key Validation ──
-	connectElem.addEventListener("click", async () => {
-		apiKeyElem.disabled = true;
-		connectElem.disabled = true;
-		connectElem.innerText = "Connecting...";
-		failedElem.classList.add("hidden");
+  function normalizeApiKey(value) {
+    if (typeof value !== "string") return "";
+    return value.trim();
+  }
 
-		try {
-			const res = await fetch("https://openapi.api.govee.com/router/api/v1/user/devices", {
-				headers: { "Content-Type": "application/json", "Govee-API-Key": apiKeyElem.value }
-			});
-			if (res.ok) {
-				SDPIComponents.streamDeckClient.setGlobalSettings({ apiKey: apiKeyElem.value });
-				showPanel(false);
-				document.querySelectorAll("sdpi-select[datasource]").forEach(el => {
-					if (el.refresh) el.refresh();
-				});
-			} else {
-				failedElem.classList.remove("hidden");
-			}
-		} catch {
-			failedElem.classList.remove("hidden");
-		}
+  function hasValidApiKey(value) {
+    return API_KEY_PATTERN.test(normalizeApiKey(value));
+  }
 
-		apiKeyElem.disabled = false;
-		connectElem.disabled = false;
-		connectElem.innerText = "Connect";
-	});
+  function injectApiKeyActions(client) {
+    if (!settingsWrapper || document.getElementById("editApiKeyBtn")) return;
 
-	// ── Group Manager (injected into every PI) ──
-	function initGroupManager(client) {
-		const container = document.getElementById("groupManager");
-		if (!container) return;
+    const item = document.createElement("sdpi-item");
+    item.setAttribute("label", "API Key");
 
-		let devices = [];
+    const button = document.createElement("button");
+    button.type = "button";
+    button.id = "editApiKeyBtn";
+    button.className = "sdpi-item-value group-cancel-btn";
+    button.textContent = "Change API Key";
+    button.addEventListener("click", () => {
+      failedElem.classList.add("hidden");
+      showPanel(true);
+      apiKeyElem.focus();
+    });
 
-		container.innerHTML = `
+    item.appendChild(button);
+    settingsWrapper.insertBefore(item, settingsWrapper.firstChild);
+  }
+
+  // ── API Key Validation ──
+  connectElem.addEventListener("click", async () => {
+    const candidateKey = normalizeApiKey(apiKeyElem.value);
+    if (!hasValidApiKey(candidateKey)) {
+      failedElem.textContent = "Please enter a valid Govee API key.";
+      failedElem.classList.remove("hidden");
+      return;
+    }
+
+    apiKeyElem.disabled = true;
+    connectElem.disabled = true;
+    connectElem.innerText = "Connecting...";
+    failedElem.classList.add("hidden");
+
+    try {
+      const res = await fetch(
+        "https://openapi.api.govee.com/router/api/v1/user/devices",
+        {
+          headers: {
+            "Content-Type": "application/json",
+            "Govee-API-Key": candidateKey,
+          },
+        },
+      );
+      if (res.ok) {
+        SDPIComponents.streamDeckClient.setGlobalSettings({
+          apiKey: candidateKey,
+        });
+        showPanel(false);
+        document.querySelectorAll("sdpi-select[datasource]").forEach((el) => {
+          if (el.refresh) el.refresh();
+        });
+      } else {
+        failedElem.textContent = "Failed to connect, please try again.";
+        failedElem.classList.remove("hidden");
+      }
+    } catch {
+      failedElem.textContent = "Failed to connect, please try again.";
+      failedElem.classList.remove("hidden");
+    }
+
+    apiKeyElem.disabled = false;
+    connectElem.disabled = false;
+    connectElem.innerText = "Connect";
+  });
+
+  // ── Group Manager (injected into every PI) ──
+  function initGroupManager(client) {
+    const container = document.getElementById("groupManager");
+    if (!container) return;
+
+    let devices = [];
+
+    container.innerHTML = `
 			<hr class="group-separator" />
 			<sdpi-item label="Groups">
 				<div>
@@ -93,158 +141,221 @@ document.addEventListener("DOMContentLoaded", () => {
 			<div id="groupStatus" class="group-status"></div>
 		`;
 
-		const groupList = document.getElementById("groupList");
-		const createForm = document.getElementById("groupCreateForm");
-		const lightList = document.getElementById("groupLightList");
-		const nameInput = document.getElementById("groupNameInput");
-		const statusEl = document.getElementById("groupStatus");
+    const groupList = document.getElementById("groupList");
+    const createForm = document.getElementById("groupCreateForm");
+    const lightList = document.getElementById("groupLightList");
+    const nameInput = document.getElementById("groupNameInput");
+    const statusEl = document.getElementById("groupStatus");
 
-		function showStatus(msg, isError) {
-			statusEl.textContent = msg;
-			statusEl.className = "group-status " + (isError ? "error" : "success");
-			setTimeout(() => { statusEl.textContent = ""; }, 3000);
-		}
+    function showStatus(msg, isError) {
+      statusEl.textContent = msg;
+      statusEl.className = "group-status " + (isError ? "error" : "success");
+      setTimeout(() => {
+        statusEl.textContent = "";
+      }, 3000);
+    }
 
-		function renderGroups(groups) {
-			groupList.innerHTML = "";
-			if (groups.length === 0) {
-				groupList.innerHTML = '<span class="group-empty">No groups yet</span>';
-				return;
-			}
-			groups.forEach(g => {
-				const row = document.createElement("div");
-				row.className = "group-row";
-				row.innerHTML = `
+    function renderGroups(groups) {
+      groupList.innerHTML = "";
+      if (groups.length === 0) {
+        groupList.innerHTML = '<span class="group-empty">No groups yet</span>';
+        return;
+      }
+      groups.forEach((g) => {
+        const row = document.createElement("div");
+        row.className = "group-row";
+        row.innerHTML = `
 					<span class="group-label">${g.name} <small>(${g.size || "?"} lights)</small></span>
 					<button class="group-delete-btn" data-id="${g.id}">✕</button>
 				`;
-				row.querySelector(".group-delete-btn").addEventListener("click", () => {
-					if (confirm("Delete group '" + g.name + "'?")) {
-						sendToPlugin({ event: "deleteGroup", groupId: g.id });
-					}
-				});
-				groupList.appendChild(row);
-			});
-		}
+        row.querySelector(".group-delete-btn").addEventListener("click", () => {
+          if (confirm("Delete group '" + g.name + "'?")) {
+            sendToPlugin({ event: "deleteGroup", groupId: g.id });
+          }
+        });
+        groupList.appendChild(row);
+      });
+    }
 
-		document.getElementById("newGroupBtn").addEventListener("click", () => {
-			nameInput.value = "";
-			lightList.innerHTML = "";
-			if (devices.length === 0) {
-				lightList.innerHTML = '<div style="padding:4px;color:#999">No devices found</div>';
-			} else {
-				devices.forEach(d => {
-					const label = document.createElement("label");
-					label.innerHTML = `<input type="checkbox" name="grpLight" value="${d.value}"> ${d.label}`;
-					lightList.appendChild(label);
-				});
-			}
-			createForm.style.display = "";
-		});
+    document.getElementById("newGroupBtn").addEventListener("click", () => {
+      nameInput.value = "";
+      lightList.innerHTML = "";
+      if (devices.length === 0) {
+        lightList.innerHTML =
+          '<div style="padding:4px;color:#999">No devices found</div>';
+      } else {
+        devices.forEach((d) => {
+          const label = document.createElement("label");
+          label.innerHTML = `<input type="checkbox" name="grpLight" value="${d.value}"> ${d.label}`;
+          lightList.appendChild(label);
+        });
+      }
+      createForm.style.display = "";
+    });
 
-		document.getElementById("cancelGroupBtn").addEventListener("click", () => {
-			createForm.style.display = "none";
-		});
+    document.getElementById("cancelGroupBtn").addEventListener("click", () => {
+      createForm.style.display = "none";
+    });
 
-		document.getElementById("saveGroupBtn").addEventListener("click", () => {
-			const name = nameInput.value.trim();
-			const checked = [...document.querySelectorAll('input[name="grpLight"]:checked')];
-			if (!name) { showStatus("Enter a name", true); return; }
-			if (checked.length === 0) { showStatus("Select lights", true); return; }
-			sendToPlugin({
-				event: "saveGroup",
-				group: { name, lightIds: checked.map(cb => cb.value) }
-			});
-		});
+    document.getElementById("saveGroupBtn").addEventListener("click", () => {
+      const name = nameInput.value.trim();
+      const checked = [
+        ...document.querySelectorAll('input[name="grpLight"]:checked'),
+      ];
+      if (!name) {
+        showStatus("Enter a name", true);
+        return;
+      }
+      if (checked.length === 0) {
+        showStatus("Select lights", true);
+        return;
+      }
+      sendToPlugin({
+        event: "saveGroup",
+        group: { name, lightIds: checked.map((cb) => cb.value) },
+      });
+    });
 
-		// Listen for backend responses via raw WebSocket
-		document.addEventListener("sdpi:message", (evt) => {
-			const p = evt.detail || {};
+    // Listen for backend responses via raw WebSocket
+    document.addEventListener("sdpi:message", (evt) => {
+      const p = evt.detail || {};
 
-			if (p.event === "getDevices" && p.items) {
-				// Flatten: items may have children (Lights/Groups optgroups)
-				devices = [];
-				(p.items || []).forEach(item => {
-					if (item.children) {
-						// Only include lights for group creation (not groups)
-						if (item.label === "Lights") {
-							devices.push(...item.children);
-						}
-					} else if (item.value) {
-						devices.push(item);
-					}
-				});
-			}
+      if (p.event === "getDevices" && p.items) {
+        // Flatten: items may have children (Lights/Groups optgroups)
+        devices = [];
+        (p.items || []).forEach((item) => {
+          if (item.children) {
+            // Only include lights for group creation (not groups)
+            if (item.label === "Lights") {
+              devices.push(...item.children);
+            }
+          } else if (item.value) {
+            devices.push(item);
+          }
+        });
+      }
 
-			if (p.event === "groupsReceived" && p.groups) {
-				renderGroups(p.groups);
-			}
+      if (p.event === "groupsReceived" && p.groups) {
+        renderGroups(p.groups);
+      }
 
-			if (p.event === "groupSaved") {
-				if (p.success) {
-					showStatus("Group created!", false);
-					createForm.style.display = "none";
-					sendToPlugin({ event: "getGroups" });
-					// Refresh device dropdown to include new group
-					document.querySelectorAll("sdpi-select[datasource]").forEach(el => {
-						if (el.refresh) el.refresh();
-					});
-				} else {
-					showStatus(p.error || "Failed", true);
-				}
-			}
+      if (p.event === "groupSaved") {
+        if (p.success) {
+          showStatus("Group created!", false);
+          createForm.style.display = "none";
+          sendToPlugin({ event: "getGroups" });
+          // Refresh device dropdown to include new group
+          document.querySelectorAll("sdpi-select[datasource]").forEach((el) => {
+            if (el.refresh) el.refresh();
+          });
+        } else {
+          showStatus(p.error || "Failed", true);
+        }
+      }
 
-			if (p.event === "groupDeleted") {
-				if (p.success) {
-					showStatus("Deleted", false);
-					sendToPlugin({ event: "getGroups" });
-					document.querySelectorAll("sdpi-select[datasource]").forEach(el => {
-						if (el.refresh) el.refresh();
-					});
-				} else {
-					showStatus(p.error || "Failed", true);
-				}
-			}
-		});
+      if (p.event === "groupDeleted") {
+        if (p.success) {
+          showStatus("Deleted", false);
+          sendToPlugin({ event: "getGroups" });
+          document.querySelectorAll("sdpi-select[datasource]").forEach((el) => {
+            if (el.refresh) el.refresh();
+          });
+        } else {
+          showStatus(p.error || "Failed", true);
+        }
+      }
+    });
 
-		// Fetch groups and devices
-		sendToPlugin({ event: "getGroups" });
-		sendToPlugin({ event: "getDevices" });
-	}
+    // Fetch groups and devices
+    sendToPlugin({ event: "getGroups" });
+    sendToPlugin({ event: "getDevices" });
+  }
 
-	// ── Initialize ──
-	function init() {
-		const client = SDPIComponents.streamDeckClient;
+  // ── Device Dropdown Timeout ──
+  // If the dropdown stays on "Loading" for too long (backend crashed or
+  // API unreachable), show a helpful hint so the user isn't stuck.
+  function watchDeviceDropdown() {
+    const TIMEOUT_MS = 15_000;
+    const deviceSelect = document.querySelector(
+      'sdpi-select[setting="selectedDeviceId"]',
+    );
+    if (!deviceSelect) return;
 
-		client.didReceiveGlobalSettings.subscribe((msg) => {
-			const apiKey = msg.payload?.settings?.apiKey;
-			showPanel(!apiKey);
-		});
+    const timer = setTimeout(() => {
+      // Check if the dropdown is still empty / loading
+      const hasOptions =
+        deviceSelect.querySelectorAll("option").length > 0 ||
+        deviceSelect.value;
+      if (hasOptions) return;
 
-		if (hasConditionalItems) {
-			client.didReceiveSettings.subscribe((msg) => {
-				const mode = msg.payload?.settings?.controlMode;
-				if (mode) updateConditionalVisibility(mode);
-			});
-		}
+      // Insert a hint below the dropdown
+      if (document.getElementById("deviceTimeout")) return;
+      const hint = document.createElement("div");
+      hint.id = "deviceTimeout";
+      hint.style.cssText =
+        "color:#FF6B6B;font-size:12px;padding:6px 0;line-height:1.4";
+      hint.textContent =
+        "Devices didn't load. Check your API key, try the refresh button, or restart the Stream Deck app.";
+      deviceSelect.parentNode.insertBefore(hint, deviceSelect.nextSibling);
+    }, TIMEOUT_MS);
 
-		client.getGlobalSettings();
-		initGroupManager(client);
-	}
+    // Clear timeout if devices arrive
+    document.addEventListener("sdpi:message", function onMsg(evt) {
+      const p = evt.detail || {};
+      if (p.event === "getDevices") {
+        clearTimeout(timer);
+        const hint = document.getElementById("deviceTimeout");
+        if (hint) hint.remove();
+        document.removeEventListener("sdpi:message", onMsg);
+      }
+    });
+  }
 
-	const check = setInterval(() => {
-		if (typeof SDPIComponents !== "undefined" && SDPIComponents.streamDeckClient) {
-			clearInterval(check);
-			init();
-		}
-	}, 50);
+  // ── Initialize ──
+  function init() {
+    const client = SDPIComponents.streamDeckClient;
+    injectApiKeyActions(client);
 
-	setTimeout(() => {
-		clearInterval(check);
-		if (setupWrapper.classList.contains("hidden") && settingsWrapper.classList.contains("hidden")) {
-			showPanel(true);
-		}
-	}, 3000);
+    client.didReceiveGlobalSettings.subscribe((msg) => {
+      const apiKey = msg.payload?.settings?.apiKey;
+      showPanel(!hasValidApiKey(apiKey));
+    });
 
-	updateConditionalVisibility("toggle");
+    if (hasConditionalItems) {
+      client.didReceiveSettings.subscribe((msg) => {
+        const mode = msg.payload?.settings?.controlMode;
+        if (mode) updateConditionalVisibility(mode);
+      });
+    }
+
+    client.getGlobalSettings();
+    watchDeviceDropdown();
+    try {
+      initGroupManager(client);
+    } catch (error) {
+      console.warn("Failed to initialize group manager", error);
+    }
+  }
+
+  const check = setInterval(() => {
+    if (
+      typeof SDPIComponents !== "undefined" &&
+      SDPIComponents.streamDeckClient
+    ) {
+      clearInterval(check);
+      init();
+    }
+  }, 50);
+
+  setTimeout(() => {
+    clearInterval(check);
+    if (
+      setupWrapper.classList.contains("hidden") &&
+      settingsWrapper.classList.contains("hidden")
+    ) {
+      showPanel(true);
+    }
+  }, 3000);
+
+  updateConditionalVisibility("toggle");
 });

--- a/com.felixgeelhaar.govee-light-management.sdPlugin/ui/js/setup.js
+++ b/com.felixgeelhaar.govee-light-management.sdPlugin/ui/js/setup.js
@@ -65,6 +65,9 @@ document.addEventListener("DOMContentLoaded", () => {
     settingsWrapper.insertBefore(item, settingsWrapper.firstChild);
   }
 
+  // Keep a reference to the latest global settings so we can merge, not replace.
+  let cachedGlobalSettings = {};
+
   // ── API Key Validation ──
   connectElem.addEventListener("click", async () => {
     const candidateKey = normalizeApiKey(apiKeyElem.value);
@@ -90,7 +93,9 @@ document.addEventListener("DOMContentLoaded", () => {
         },
       );
       if (res.ok) {
+        // Merge with existing global settings to preserve light groups etc.
         SDPIComponents.streamDeckClient.setGlobalSettings({
+          ...cachedGlobalSettings,
           apiKey: candidateKey,
         });
         showPanel(false);
@@ -98,11 +103,15 @@ document.addEventListener("DOMContentLoaded", () => {
           if (el.refresh) el.refresh();
         });
       } else {
-        failedElem.textContent = "Failed to connect, please try again.";
+        failedElem.textContent =
+          res.status === 401
+            ? "Invalid API key. Please check and try again."
+            : "Failed to connect, please try again.";
         failedElem.classList.remove("hidden");
       }
     } catch {
-      failedElem.textContent = "Failed to connect, please try again.";
+      failedElem.textContent =
+        "Could not reach Govee servers. Check your internet connection.";
       failedElem.classList.remove("hidden");
     }
 
@@ -317,7 +326,8 @@ document.addEventListener("DOMContentLoaded", () => {
     injectApiKeyActions(client);
 
     client.didReceiveGlobalSettings.subscribe((msg) => {
-      const apiKey = msg.payload?.settings?.apiKey;
+      cachedGlobalSettings = msg.payload?.settings || {};
+      const apiKey = cachedGlobalSettings.apiKey;
       showPanel(!hasValidApiKey(apiKey));
     });
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "govee-light-management",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "Enterprise-grade Stream Deck plugin for managing Govee lights with advanced group functionality",
   "main": "com.felixgeelhaar.govee-light-management.sdPlugin/bin/plugin.js",
   "scripts": {

--- a/test/backend/connectivity/TransportOrchestrator.test.ts
+++ b/test/backend/connectivity/TransportOrchestrator.test.ts
@@ -84,6 +84,49 @@ describe("TransportOrchestrator", () => {
     expect(result.stale).toBe(false);
   });
 
+  it("continues discovery when one transport throws (e.g. validation error)", async () => {
+    const validLight = {
+      deviceId: "dev-1",
+      model: "H6001",
+      name: "Living Room",
+      label: "Living Room",
+      value: "dev-1|H6001",
+      controllable: true,
+      retrievable: true,
+      supportedCommands: [],
+    };
+
+    // Primary transport throws (simulates Zod ValidationError from group entries)
+    (primary.discoverDevices as any).mockRejectedValue(
+      new Error("API response validation failed"),
+    );
+    // Secondary transport succeeds
+    (secondary.discoverDevices as any).mockResolvedValue({
+      lights: [validLight],
+      stale: false,
+    } satisfies DeviceDiscoveryResult);
+
+    const result = await orchestrator.discoverDevices();
+
+    // Should still return the lights from the working transport
+    expect(result.lights).toHaveLength(1);
+    expect(result.lights[0].deviceId).toBe("dev-1");
+  });
+
+  it("returns empty when all transports fail", async () => {
+    (primary.discoverDevices as any).mockRejectedValue(
+      new Error("API response validation failed"),
+    );
+    (secondary.discoverDevices as any).mockRejectedValue(
+      new Error("Network timeout"),
+    );
+
+    const result = await orchestrator.discoverDevices();
+
+    expect(result.lights).toHaveLength(0);
+    expect(result.stale).toBe(true);
+  });
+
   it("refreshes transport health and exposes snapshots", async () => {
     const healthPrimary: TransportHealth = {
       descriptor: primary.descriptor,

--- a/test/backend/services/DeviceService.test.ts
+++ b/test/backend/services/DeviceService.test.ts
@@ -90,6 +90,56 @@ describe("DeviceService", () => {
     expect(orchestrator.discoverDevices).toHaveBeenCalledTimes(3);
   });
 
+  it("falls back to cached data when discovery throws", async () => {
+    const orchestrator = createOrchestratorMock();
+    const cachedLight = {
+      deviceId: "dev-1",
+      model: "H6001",
+      name: "Living Room",
+      label: "Living Room",
+      value: "dev-1|H6001",
+      controllable: true,
+      retrievable: true,
+      supportedCommands: ["Power"],
+    };
+
+    // First call succeeds and populates cache
+    orchestrator.discoverDevices.mockResolvedValueOnce({
+      lights: [cachedLight],
+      stale: false,
+    });
+
+    const service = new DeviceService(orchestrator as any, {
+      cacheTtlMs: 500,
+    });
+    const first = await service.discover();
+    expect(first).toHaveLength(1);
+
+    // Expire cache
+    vi.advanceTimersByTime(501);
+
+    // Second call throws (simulates Zod ValidationError from group entries)
+    orchestrator.discoverDevices.mockRejectedValueOnce(
+      new Error("API response validation failed"),
+    );
+
+    // Should return cached data instead of crashing
+    const second = await service.discover();
+    expect(second).toHaveLength(1);
+    expect(second[0].deviceId).toBe("dev-1");
+  });
+
+  it("returns empty array when discovery throws with no cache", async () => {
+    const orchestrator = createOrchestratorMock();
+    orchestrator.discoverDevices.mockRejectedValue(
+      new Error("API response validation failed"),
+    );
+
+    const service = new DeviceService(orchestrator as any);
+    const result = await service.discover();
+    expect(result).toEqual([]);
+  });
+
   it("returns cached lights when available", () => {
     const orchestrator = createOrchestratorMock();
     const service = new DeviceService(orchestrator as any);


### PR DESCRIPTION
## Summary

- Device dropdown now shows a helpful error after 15 seconds instead of staying on "Loading" forever
- API key save no longer wipes other global settings (light groups, etc.)
- Better error messages: 401 = "Invalid API key", network error = "Could not reach Govee servers"
- 4 regression tests for discovery error resilience (#161)

## Fixes

- #161 (regression tests)
- #162 (loading timeout)

## Test Plan

- [x] TypeScript: zero errors
- [x] Tests: 262/262 passing (4 new regression tests)
- [x] Lint: clean
- [x] Build: successful
- [x] On/Off toggle verified via Elgato Stream Deck MCP