### PR TITLE
Live dial state syncing and dial value feedback

### DIFF
--- a/src/backend/actions/BrightnessDialAction.ts
+++ b/src/backend/actions/BrightnessDialAction.ts
@@ -16,6 +16,10 @@ const DEFAULT_BAR_BG = "#1F2937"; // dark gray
 
 @action({ UUID: "com.felixgeelhaar.govee-light-management.brightness-dial" })
 export class BrightnessDialAction extends BaseDialAction<BrightnessDialSettings> {
+  private static deviceStateCache = new Map<
+    string,
+    { brightness: number; isOn: boolean }
+  >();
   private brightnessMap = new Map<string, number>();
 
   protected initValueMaps(ctx: string): void {
@@ -35,6 +39,12 @@ export class BrightnessDialAction extends BaseDialAction<BrightnessDialSettings>
     const current = this.brightnessMap.get(ctx) ?? 50;
     const next = clamp(current + ev.payload.ticks * step, 0, 100);
     this.brightnessMap.set(ctx, next);
+    if (settings.selectedDeviceId) {
+      BrightnessDialAction.deviceStateCache.set(settings.selectedDeviceId, {
+        brightness: next,
+        isOn: this.powerMap.get(ctx) ?? true,
+      });
+    }
 
     await this.updateDisplay(ev.action, settings);
 
@@ -73,18 +83,34 @@ export class BrightnessDialAction extends BaseDialAction<BrightnessDialSettings>
     ctx: string,
     settings: BrightnessDialSettings,
   ): Promise<void> {
+    const deviceId = settings.selectedDeviceId;
+    if (deviceId) {
+      const cached = BrightnessDialAction.deviceStateCache.get(deviceId);
+      if (cached) {
+        this.powerMap.set(ctx, cached.isOn);
+        this.brightnessMap.set(ctx, cached.brightness);
+      }
+    }
+
     const apiKey = await this.services.getApiKey(settings);
-    if (!apiKey || !settings.selectedDeviceId) return;
+    if (!apiKey || !deviceId) return;
 
     try {
       await this.services.ensureServices(apiKey);
       const target = await this.services.resolveTarget(settings);
       if (target?.type === "light" && target.light) {
-        await this.services.syncLightState(target.light);
+        const synced = await this.services.syncLightState(target.light);
+        if (!synced) {
+          return;
+        }
         this.powerMap.set(ctx, target.light.isOn);
         if (target.light.brightness) {
           this.brightnessMap.set(ctx, target.light.brightness.level);
         }
+        BrightnessDialAction.deviceStateCache.set(deviceId, {
+          brightness: this.brightnessMap.get(ctx) ?? 50,
+          isOn: this.powerMap.get(ctx) ?? true,
+        });
       }
     } catch {
       // Best effort - keep defaults
@@ -98,11 +124,13 @@ export class BrightnessDialAction extends BaseDialAction<BrightnessDialSettings>
     const ctx = action.id || "default";
     const brightness = this.brightnessMap.get(ctx) ?? 50;
     const isOn = this.powerMap.get(ctx) ?? true;
+    const title = isOn ? `${brightness}%` : "Off";
 
     await action.setFeedback({
       label: "Brightness",
-      value: isOn ? `${brightness}%` : "Off",
+      value: title,
       bar: { value: isOn ? brightness : 0 },
     });
+    await action.setTitle(title);
   }
 }

--- a/src/backend/actions/ColorHueDialAction.ts
+++ b/src/backend/actions/ColorHueDialAction.ts
@@ -19,6 +19,7 @@ const DEFAULT_BAR_BG =
 
 @action({ UUID: "com.felixgeelhaar.govee-light-management.colorhue-dial" })
 export class ColorHueDialAction extends BaseDialAction<ColorHueDialSettings> {
+  private static deviceStateCache = new Map<string, { hue: number; isOn: boolean }>();
   private hueMap = new Map<string, number>();
 
   protected initValueMaps(ctx: string): void {
@@ -38,6 +39,12 @@ export class ColorHueDialAction extends BaseDialAction<ColorHueDialSettings> {
     const current = this.hueMap.get(ctx) ?? 0;
     const next = (((current + ev.payload.ticks * step) % 360) + 360) % 360;
     this.hueMap.set(ctx, next);
+    if (settings.selectedDeviceId) {
+      ColorHueDialAction.deviceStateCache.set(settings.selectedDeviceId, {
+        hue: next,
+        isOn: this.powerMap.get(ctx) ?? true,
+      });
+    }
 
     await this.updateDisplay(ev.action, settings);
 
@@ -74,18 +81,34 @@ export class ColorHueDialAction extends BaseDialAction<ColorHueDialSettings> {
     ctx: string,
     settings: ColorHueDialSettings,
   ): Promise<void> {
+    const deviceId = settings.selectedDeviceId;
+    if (deviceId) {
+      const cached = ColorHueDialAction.deviceStateCache.get(deviceId);
+      if (cached) {
+        this.powerMap.set(ctx, cached.isOn);
+        this.hueMap.set(ctx, cached.hue);
+      }
+    }
+
     const apiKey = await this.services.getApiKey(settings);
-    if (!apiKey || !settings.selectedDeviceId) return;
+    if (!apiKey || !deviceId) return;
 
     try {
       await this.services.ensureServices(apiKey);
       const target = await this.services.resolveTarget(settings);
       if (target?.type === "light" && target.light) {
-        await this.services.syncLightState(target.light);
+        const synced = await this.services.syncLightState(target.light);
+        if (!synced) {
+          return;
+        }
         this.powerMap.set(ctx, target.light.isOn);
         if (target.light.color) {
           this.hueMap.set(ctx, rgbToHue(target.light.color));
         }
+        ColorHueDialAction.deviceStateCache.set(deviceId, {
+          hue: this.hueMap.get(ctx) ?? 0,
+          isOn: this.powerMap.get(ctx) ?? true,
+        });
       }
     } catch {
       // Best effort - keep defaults
@@ -99,11 +122,13 @@ export class ColorHueDialAction extends BaseDialAction<ColorHueDialSettings> {
     const ctx = action.id || "default";
     const hue = this.hueMap.get(ctx) ?? 0;
     const isOn = this.powerMap.get(ctx) ?? true;
+    const title = isOn ? `${hue} deg` : "Off";
 
     await action.setFeedback({
       label: "Color",
       value: isOn ? `${hue}°` : "Off",
       bar: { value: isOn ? Math.round((hue / 360) * 100) : 0 },
     });
+    await action.setTitle(title);
   }
 }

--- a/src/backend/actions/ColorTempDialAction.ts
+++ b/src/backend/actions/ColorTempDialAction.ts
@@ -2,6 +2,7 @@ import {
   action,
   type DialAction,
   type DialRotateEvent,
+  streamDeck,
 } from "@elgato/streamdeck";
 import type { JsonObject } from "@elgato/utils";
 import { ColorTemperature } from "@felixgeelhaar/govee-api-client";
@@ -22,7 +23,15 @@ const DEFAULT_BAR_BG = "0:#FFB347,1:#A8D8EA"; // warm→cool gradient
 
 @action({ UUID: "com.felixgeelhaar.govee-light-management.colortemp-dial" })
 export class ColorTempDialAction extends BaseDialAction<ColorTempDialSettings> {
+  private static deviceStateCache = new Map<
+    string,
+    { kelvin: number; isOn: boolean }
+  >();
   private tempMap = new Map<string, number>();
+  private tempRangeMap = new Map<
+    string,
+    { min: number; max: number; precision: number }
+  >();
 
   protected initValueMaps(ctx: string): void {
     if (!this.tempMap.has(ctx)) this.tempMap.set(ctx, DEFAULT_KELVIN);
@@ -30,6 +39,7 @@ export class ColorTempDialAction extends BaseDialAction<ColorTempDialSettings> {
 
   protected cleanupValueMaps(ctx: string): void {
     this.tempMap.delete(ctx);
+    this.tempRangeMap.delete(ctx);
   }
 
   override async onDialRotate(
@@ -38,13 +48,23 @@ export class ColorTempDialAction extends BaseDialAction<ColorTempDialSettings> {
     const { settings } = ev.payload;
     const ctx = ev.action.id;
     const step = clamp(settings.stepSize || DEFAULT_STEP_KELVIN, 50, 500);
-    const current = this.tempMap.get(ctx) ?? DEFAULT_KELVIN;
-    const next = clamp(
+    const range = await this.getTemperatureRange(settings, ctx);
+    const current =
+      this.tempMap.get(ctx) ??
+      this.getDefaultKelvinForRange(range.min, range.max, range.precision);
+    const next = this.normalizeKelvin(
       current + ev.payload.ticks * step,
-      MIN_KELVIN,
-      MAX_KELVIN,
+      range.min,
+      range.max,
+      range.precision,
     );
     this.tempMap.set(ctx, next);
+    if (settings.selectedDeviceId) {
+      ColorTempDialAction.deviceStateCache.set(settings.selectedDeviceId, {
+        kelvin: next,
+        isOn: this.powerMap.get(ctx) ?? true,
+      });
+    }
 
     await this.updateDisplay(ev.action, settings);
 
@@ -56,7 +76,24 @@ export class ColorTempDialAction extends BaseDialAction<ColorTempDialSettings> {
         await this.services.ensureServices(apiKey);
         const target = await this.services.resolveTarget(settings);
         if (!target) return;
-        const finalKelvin = this.tempMap.get(ctx) ?? next;
+        const finalKelvin = this.normalizeKelvin(
+          this.tempMap.get(ctx) ?? next,
+          range.min,
+          range.max,
+          range.precision,
+        );
+        if (target.type === "light" && target.light) {
+          streamDeck.logger.info("dial.colortemp.apply.command", {
+            selectedDeviceId: settings.selectedDeviceId,
+            deviceId: target.light.deviceId,
+            model: target.light.model,
+            name: target.light.name,
+            kelvin: finalKelvin,
+            minKelvin: range.min,
+            maxKelvin: range.max,
+            precision: range.precision,
+          });
+        }
         await this.services.controlTarget(
           target,
           "colorTemperature",
@@ -67,10 +104,23 @@ export class ColorTempDialAction extends BaseDialAction<ColorTempDialSettings> {
       {
         action: ev.action,
         getRestoreValue: () => {
-          const kelvin = this.tempMap.get(ctx) ?? DEFAULT_KELVIN;
+          const localRange = this.tempRangeMap.get(ctx) ?? {
+            min: MIN_KELVIN,
+            max: MAX_KELVIN,
+            precision: DEFAULT_STEP_KELVIN,
+          };
+          const kelvin =
+            this.tempMap.get(ctx) ??
+            this.getDefaultKelvinForRange(
+              localRange.min,
+              localRange.max,
+              localRange.precision,
+            );
           const isOn = this.powerMap.get(ctx) ?? true;
-          const barValue = Math.round(
-            ((kelvin - MIN_KELVIN) / (MAX_KELVIN - MIN_KELVIN)) * 100,
+          const barValue = this.toBarValue(
+            kelvin,
+            localRange.min,
+            localRange.max,
           );
           return isOn ? barValue : 0;
         },
@@ -86,18 +136,49 @@ export class ColorTempDialAction extends BaseDialAction<ColorTempDialSettings> {
     ctx: string,
     settings: ColorTempDialSettings,
   ): Promise<void> {
+    const deviceId = settings.selectedDeviceId;
+    if (deviceId) {
+      const cached = ColorTempDialAction.deviceStateCache.get(deviceId);
+      if (cached) {
+        this.powerMap.set(ctx, cached.isOn);
+        this.tempMap.set(ctx, cached.kelvin);
+      }
+    }
+
     const apiKey = await this.services.getApiKey(settings);
-    if (!apiKey || !settings.selectedDeviceId) return;
+    if (!apiKey || !deviceId) return;
 
     try {
       await this.services.ensureServices(apiKey);
+      const range = await this.getTemperatureRange(settings, ctx);
       const target = await this.services.resolveTarget(settings);
       if (target?.type === "light" && target.light) {
-        await this.services.syncLightState(target.light);
+        const synced = await this.services.syncLightState(target.light);
+        if (!synced) {
+          return;
+        }
         this.powerMap.set(ctx, target.light.isOn);
         if (target.light.colorTemperature) {
-          this.tempMap.set(ctx, target.light.colorTemperature.kelvin);
+          this.tempMap.set(
+            ctx,
+            this.normalizeKelvin(
+              target.light.colorTemperature.kelvin,
+              range.min,
+              range.max,
+              range.precision,
+            ),
+          );
         }
+        ColorTempDialAction.deviceStateCache.set(deviceId, {
+          kelvin:
+            this.tempMap.get(ctx) ??
+            this.getDefaultKelvinForRange(
+              range.min,
+              range.max,
+              range.precision,
+            ),
+          isOn: this.powerMap.get(ctx) ?? true,
+        });
       }
     } catch {
       // Best effort - keep defaults
@@ -106,19 +187,69 @@ export class ColorTempDialAction extends BaseDialAction<ColorTempDialSettings> {
 
   protected async updateDisplay(
     action: DialAction<ColorTempDialSettings & JsonObject>,
-    _settings: ColorTempDialSettings,
+    settings: ColorTempDialSettings,
   ): Promise<void> {
     const ctx = action.id || "default";
-    const kelvin = this.tempMap.get(ctx) ?? DEFAULT_KELVIN;
+    const range = this.tempRangeMap.get(ctx) ??
+      (await this.getTemperatureRange(settings, ctx));
+    const kelvin =
+      this.tempMap.get(ctx) ??
+      this.getDefaultKelvinForRange(range.min, range.max, range.precision);
     const isOn = this.powerMap.get(ctx) ?? true;
-    const barValue = Math.round(
-      ((kelvin - MIN_KELVIN) / (MAX_KELVIN - MIN_KELVIN)) * 100,
-    );
+    const barValue = this.toBarValue(kelvin, range.min, range.max);
+    const title = isOn ? `${kelvin}K` : "Off";
 
     await action.setFeedback({
       label: "Temperature",
-      value: isOn ? `${kelvin}K` : "Off",
+      value: title,
       bar: { value: isOn ? barValue : 0 },
     });
+    await action.setTitle(title);
+  }
+
+  private async getTemperatureRange(
+    settings: ColorTempDialSettings,
+    ctx: string,
+  ): Promise<{ min: number; max: number; precision: number }> {
+    const cached = this.tempRangeMap.get(ctx);
+    if (cached) {
+      return cached;
+    }
+
+    const lightItem = await this.services.getLightItem(settings);
+    const min = lightItem?.properties?.colorTem?.range?.min ?? MIN_KELVIN;
+    const max = lightItem?.properties?.colorTem?.range?.max ?? MAX_KELVIN;
+    const precision =
+      lightItem?.properties?.colorTem?.range?.precision ?? DEFAULT_STEP_KELVIN;
+    const range = { min, max, precision: Math.max(1, precision) };
+    this.tempRangeMap.set(ctx, range);
+    return range;
+  }
+
+  private getDefaultKelvinForRange(
+    min: number,
+    max: number,
+    precision: number,
+  ): number {
+    return this.normalizeKelvin(DEFAULT_KELVIN, min, max, precision);
+  }
+
+  private toBarValue(kelvin: number, min: number, max: number): number {
+    if (max <= min) {
+      return 0;
+    }
+    return Math.round(((kelvin - min) / (max - min)) * 100);
+  }
+
+  private normalizeKelvin(
+    kelvin: number,
+    min: number,
+    max: number,
+    precision: number,
+  ): number {
+    const clamped = clamp(kelvin, min, max);
+    const step = Math.max(1, precision);
+    const snapped = min + Math.round((clamped - min) / step) * step;
+    return clamp(snapped, min, max);
   }
 }

--- a/src/backend/actions/SegmentColorDialAction.ts
+++ b/src/backend/actions/SegmentColorDialAction.ts
@@ -1,8 +1,10 @@
 import {
   action,
   type DialAction,
+  type DialDownEvent,
   type DialRotateEvent,
   streamDeck,
+  type TouchTapEvent,
 } from "@elgato/streamdeck";
 import type { JsonObject } from "@elgato/utils";
 import { BaseDialAction, type BaseDialSettings } from "./shared/BaseDialAction";
@@ -24,6 +26,7 @@ const DEFAULT_BAR_BG =
   UUID: "com.felixgeelhaar.govee-light-management.segment-color-dial",
 })
 export class SegmentColorDialAction extends BaseDialAction<SegmentColorDialSettings> {
+  private static deviceStateCache = new Map<string, { hue: number; isOn: boolean }>();
   private hueMap = new Map<string, number>();
 
   protected initValueMaps(ctx: string): void {
@@ -32,6 +35,18 @@ export class SegmentColorDialAction extends BaseDialAction<SegmentColorDialSetti
 
   protected cleanupValueMaps(ctx: string): void {
     this.hueMap.delete(ctx);
+  }
+
+  override async onDialDown(
+    ev: DialDownEvent<SegmentColorDialSettings>,
+  ): Promise<void> {
+    await this.applyCurrentSegmentColor(ev.action, ev.payload.settings);
+  }
+
+  override async onTouchTap(
+    ev: TouchTapEvent<SegmentColorDialSettings>,
+  ): Promise<void> {
+    await this.applyCurrentSegmentColor(ev.action, ev.payload.settings);
   }
 
   override async onDialRotate(
@@ -43,14 +58,22 @@ export class SegmentColorDialAction extends BaseDialAction<SegmentColorDialSetti
     const current = this.hueMap.get(ctx) ?? 0;
     const next = (((current + ev.payload.ticks * step) % 360) + 360) % 360;
     this.hueMap.set(ctx, next);
+    const cacheKey = this.getCacheKey(settings);
+    if (cacheKey) {
+      SegmentColorDialAction.deviceStateCache.set(cacheKey, {
+        hue: next,
+        isOn: this.powerMap.get(ctx) ?? true,
+      });
+    }
 
     await this.updateDisplay(ev.action, settings);
 
     this.services.deferDialAction(
       ctx,
       async () => {
+        const currentSettings = this.getCurrentSettings(ctx, settings);
         const finalHue = this.hueMap.get(ctx) ?? next;
-        await this.applyToSegment(settings, finalHue);
+        await this.applyToSegment(currentSettings, finalHue);
       },
       undefined,
       {
@@ -72,6 +95,12 @@ export class SegmentColorDialAction extends BaseDialAction<SegmentColorDialSetti
     settings: SegmentColorDialSettings,
     hue: number,
   ): Promise<void> {
+    streamDeck.logger.info("segment.dial.apply.request", {
+      selectedDeviceId: settings.selectedDeviceId ?? null,
+      segmentIndex: settings.segmentIndex ?? 1,
+      hue,
+      saturation: settings.saturation ?? 100,
+    });
     const apiKey = await this.services.getApiKey(settings);
     if (!apiKey || !settings.selectedDeviceId) {
       streamDeck.logger.warn(
@@ -87,14 +116,54 @@ export class SegmentColorDialAction extends BaseDialAction<SegmentColorDialSetti
       );
       throw new Error("Could not resolve target device");
     }
+    if (!target.light.supportsSegmentedColor()) {
+      streamDeck.logger.warn("segment.dial.unsupported-device", {
+        selectedDeviceId: settings.selectedDeviceId,
+        deviceId: target.light.deviceId,
+        model: target.light.model,
+        name: target.light.name,
+      });
+      throw new Error("Selected light does not support segmented color");
+    }
 
     const saturation = clamp(settings.saturation ?? 100, 0, 100);
     const color = hsvToRgb(hue, saturation, 100);
     // UI stores 1-based index (1–15), translate to 0-based (0–14) for the API
     const segmentIndex = clamp((settings.segmentIndex ?? 1) - 1, 0, 14);
+    streamDeck.logger.info("segment.dial.apply.command", {
+      deviceId: target.light.deviceId,
+      model: target.light.model,
+      name: target.light.name,
+      segmentIndex,
+      hue,
+      saturation,
+      color: color.toObject(),
+    });
     await this.services.setSegmentColors(target.light, [
       SegmentColor.create(segmentIndex, color),
     ]);
+    streamDeck.logger.info("segment.dial.apply.success", {
+      deviceId: target.light.deviceId,
+      model: target.light.model,
+      name: target.light.name,
+      segmentIndex,
+    });
+  }
+
+  private async applyCurrentSegmentColor(
+    action: DialAction<SegmentColorDialSettings & JsonObject>,
+    fallbackSettings: SegmentColorDialSettings,
+  ): Promise<void> {
+    const ctx = action.id;
+    const settings = this.getCurrentSettings(ctx, fallbackSettings);
+    const hue = this.hueMap.get(ctx) ?? 0;
+
+    try {
+      await this.applyToSegment(settings, hue);
+    } catch (error) {
+      streamDeck.logger.error("Failed to apply segment color:", error);
+      await action.showAlert();
+    }
   }
 
   /**
@@ -105,6 +174,15 @@ export class SegmentColorDialAction extends BaseDialAction<SegmentColorDialSetti
     ctx: string,
     settings: SegmentColorDialSettings,
   ): Promise<void> {
+    const cacheKey = this.getCacheKey(settings);
+    if (cacheKey) {
+      const cached = SegmentColorDialAction.deviceStateCache.get(cacheKey);
+      if (cached) {
+        this.powerMap.set(ctx, cached.isOn);
+        this.hueMap.set(ctx, cached.hue);
+      }
+    }
+
     const apiKey = await this.services.getApiKey(settings);
     if (!apiKey || !settings.selectedDeviceId) return;
 
@@ -115,6 +193,12 @@ export class SegmentColorDialAction extends BaseDialAction<SegmentColorDialSetti
         const isOn = await this.services.getLivePowerState(target.light);
         if (isOn !== undefined) {
           this.powerMap.set(ctx, isOn);
+          if (cacheKey) {
+            SegmentColorDialAction.deviceStateCache.set(cacheKey, {
+              hue: this.hueMap.get(ctx) ?? 0,
+              isOn,
+            });
+          }
         }
       }
     } catch {
@@ -131,11 +215,20 @@ export class SegmentColorDialAction extends BaseDialAction<SegmentColorDialSetti
     const isOn = this.powerMap.get(ctx) ?? true;
     // Display 1-based segment number to match the UI
     const segmentDisplay = settings.segmentIndex ?? 1;
+    const title = isOn ? `S${segmentDisplay}\n${hue}` : `S${segmentDisplay}\nOff`;
 
     await action.setFeedback({
       label: `Segment ${segmentDisplay}`,
       value: isOn ? `${hue}°` : "Off",
       bar: { value: isOn ? Math.round((hue / 360) * 100) : 0 },
     });
+    await action.setTitle(title);
+  }
+
+  private getCacheKey(settings: SegmentColorDialSettings): string | null {
+    if (!settings.selectedDeviceId) {
+      return null;
+    }
+    return `${settings.selectedDeviceId}|segment:${settings.segmentIndex ?? 1}`;
   }
 }

--- a/src/backend/actions/shared/ActionServices.ts
+++ b/src/backend/actions/shared/ActionServices.ts
@@ -28,7 +28,7 @@ import { globalSettingsService } from "../../services/GlobalSettingsService";
 import { StreamDeckLightGroupRepository } from "../../infrastructure/repositories/StreamDeckLightGroupRepository";
 import { LightGroupService } from "../../domain/services/LightGroupService";
 import { SegmentColor } from "../../domain/value-objects/SegmentColor";
-import { isValidationError } from "./validation";
+import { isIgnorableLiveStateError, isValidationError } from "./validation";
 
 /** Default timeout for API calls in PI handlers (10 seconds) */
 const PI_HANDLER_TIMEOUT_MS = 10_000;
@@ -38,6 +38,9 @@ const FLASH_SUCCESS = "#22CC66"; // green – command succeeded
 const FLASH_ERROR = "#FF3333"; // red – command failed
 const FLASH_LOADING_DELAY_MS = 250; // only show loading if request is noticeably slow
 const FLASH_RESULT_MS = 400; // how long success/error flash stays visible
+const LIVE_STATE_RETRY_BACKOFF_MS = 30_000;
+const RATE_LIMIT_RETRY_BACKOFF_MS = 60_000;
+const LIVE_STATE_MIN_REFRESH_MS = 3_000;
 
 /**
  * Send a payload to the Property Inspector for the currently visible action.
@@ -135,6 +138,11 @@ export class ActionServices {
     /** Guards concurrent ensureServices calls to prevent interleaving. */
     initPromise?: Promise<void>;
   } = {};
+  private static liveStateBlockedUntil = new Map<string, number>();
+  private static liveStateLogged = new Set<string>();
+  private static lightStateSnapshots = new Map<string, LightState>();
+  private static lightStateSyncedAt = new Map<string, number>();
+  private static liveStateSyncInFlight = new Map<string, Promise<boolean>>();
 
   get lightRepository() {
     return ActionServices._shared.lightRepository;
@@ -147,6 +155,84 @@ export class ActionServices {
   }
   get deviceService() {
     return ActionServices._shared.deviceService;
+  }
+
+  private getLightSnapshotKey(light: Pick<Light, "deviceId" | "model">): string {
+    return `${light.deviceId}|${light.model}`;
+  }
+
+  private hydrateFromSnapshot(light: Light): void {
+    const snapshot = ActionServices.lightStateSnapshots.get(
+      this.getLightSnapshotKey(light),
+    );
+    if (snapshot) {
+      light.updateState(snapshot);
+    }
+  }
+
+  private rememberLightState(light: Light): void {
+    ActionServices.lightStateSnapshots.set(
+      this.getLightSnapshotKey(light),
+      light.state,
+    );
+    ActionServices.lightStateSyncedAt.set(
+      this.getLightSnapshotKey(light),
+      Date.now(),
+    );
+  }
+
+  private getKnownPowerState(light: Pick<Light, "deviceId" | "model">):
+    | boolean
+    | undefined {
+    return ActionServices.lightStateSnapshots.get(this.getLightSnapshotKey(light))
+      ?.isOn;
+  }
+
+  private hasFreshSnapshot(light: Pick<Light, "deviceId" | "model">): boolean {
+    const syncedAt = ActionServices.lightStateSyncedAt.get(
+      this.getLightSnapshotKey(light),
+    );
+    return (
+      typeof syncedAt === "number" &&
+      Date.now() - syncedAt < LIVE_STATE_MIN_REFRESH_MS
+    );
+  }
+
+  private isRateLimitError(error: unknown): boolean {
+    const message = error instanceof Error ? error.message : String(error);
+    return message.toLowerCase().includes("rate limit exceeded");
+  }
+
+  private isNonRetryableControlError(error: unknown): boolean {
+    const message = error instanceof Error ? error.message : String(error);
+    const normalized = message.toLowerCase();
+    return (
+      normalized.includes("parameter value out of range") ||
+      normalized.includes("failed to set color temperature: api returned error code 400")
+    );
+  }
+
+  async getLightItem(
+    settings: BaseSettings,
+  ): Promise<import("@shared/types").LightItem | undefined> {
+    const target = this.parseTarget(settings);
+    if (
+      !target ||
+      target.type !== "light" ||
+      !target.deviceId ||
+      !target.model ||
+      !this.deviceService
+    ) {
+      return undefined;
+    }
+
+    const lights =
+      this.deviceService.getCachedLights() ??
+      (await this.deviceService.discover(false));
+    return lights.find(
+      (light) =>
+        light.deviceId === target.deviceId && light.model === target.model,
+    );
   }
 
   /**
@@ -316,6 +402,7 @@ export class ActionServices {
           initialState,
           capabilities,
         );
+        this.hydrateFromSnapshot(light);
         return { type: "light", light };
       }
     }
@@ -741,6 +828,17 @@ export class ActionServices {
   }
 
   /**
+   * Returns true while a dial has a deferred command queued or its success/error
+   * flash is still active. Used to avoid live-state refreshes fighting with
+   * immediate user feedback.
+   */
+  isDialInteractionActive(contextId: string): boolean {
+    return (
+      this.dialTimers.has(contextId) || this.restoreTimers.has(contextId)
+    );
+  }
+
+  /**
    * Show a spinner on a key while an async operation runs.
    * Returns a function to stop the spinner.
    */
@@ -784,6 +882,7 @@ export class ActionServices {
             command,
             value,
           );
+          this.rememberLightState(target.light);
         } else if (target.type === "group" && target.group) {
           await this.lightControlService!.controlGroup(
             target.group,
@@ -793,7 +892,10 @@ export class ActionServices {
         }
       } catch (error) {
         // Don't retry on validation errors - these are likely API issues
-        if (isValidationError(error)) {
+        if (
+          isValidationError(error) ||
+          this.isNonRetryableControlError(error)
+        ) {
           throw error;
         }
         if (attempt < maxRetries) {
@@ -860,16 +962,79 @@ export class ActionServices {
     return this.lightRepository.getToggleState(light, instance);
   }
 
-  async syncLightState(light: Light): Promise<void> {
-    if (!this.lightRepository) {
+  async syncLightState(light: Light): Promise<boolean> {
+    const lightRepository = this.lightRepository;
+    if (!lightRepository) {
       throw new Error("Light repository not initialized");
     }
-    await this.lightRepository.getLightState(light);
+    this.hydrateFromSnapshot(light);
+    if (this.hasFreshSnapshot(light)) {
+      return true;
+    }
+    if (this.isLiveStateTemporarilyBlocked(light, "full-state")) {
+      return false;
+    }
+
+    const snapshotKey = this.getLightSnapshotKey(light);
+    const inFlight = ActionServices.liveStateSyncInFlight.get(snapshotKey);
+    if (inFlight) {
+      await inFlight;
+      this.hydrateFromSnapshot(light);
+      return this.hasFreshSnapshot(light);
+    }
+
+    const syncPromise = (async () => {
+      try {
+        await lightRepository.getLightState(light);
+        this.clearLiveStateBlock(light, "full-state");
+        this.rememberLightState(light);
+        return true;
+      } catch (error) {
+        if (this.handleIgnorableLiveStateError(light, error, "full-state")) {
+          return false;
+        }
+        if (this.isRateLimitError(error)) {
+          this.blockLiveState(
+            light,
+            "full-state",
+            RATE_LIMIT_RETRY_BACKOFF_MS,
+            error,
+          );
+          return false;
+        }
+        throw error;
+      } finally {
+        ActionServices.liveStateSyncInFlight.delete(snapshotKey);
+      }
+    })();
+
+    ActionServices.liveStateSyncInFlight.set(snapshotKey, syncPromise);
+
+    const synced = await syncPromise;
+    this.hydrateFromSnapshot(light);
+    return synced || this.hasFreshSnapshot(light);
   }
 
   async getLivePowerState(light: Light): Promise<boolean | undefined> {
+    this.hydrateFromSnapshot(light);
+
+    if (this.lightRepository) {
+      try {
+        const synced = await this.syncLightState(light);
+        if (synced) {
+          return light.isOn;
+        }
+      } catch {
+        // Fall through to transport power-state lookup below.
+      }
+    }
+
     if (!this.deviceService) {
-      return undefined;
+      return this.getKnownPowerState(light);
+    }
+
+    if (this.isLiveStateTemporarilyBlocked(light, "power-state")) {
+      return this.getKnownPowerState(light);
     }
 
     try {
@@ -885,13 +1050,33 @@ export class ActionServices {
         isOnline: result.state.isOnline,
         transport: result.transport,
       });
+      if (typeof result.state.powerState === "boolean") {
+        light.updateState({
+          isOn: result.state.powerState,
+          isOnline: result.state.isOnline,
+        });
+        this.rememberLightState(light);
+      }
+      this.clearLiveStateBlock(light, "power-state");
       return result.state.powerState;
     } catch (error) {
+      if (this.handleIgnorableLiveStateError(light, error, "power-state")) {
+        return this.getKnownPowerState(light);
+      }
+      if (this.isRateLimitError(error)) {
+        this.blockLiveState(
+          light,
+          "power-state",
+          RATE_LIMIT_RETRY_BACKOFF_MS,
+          error,
+        );
+        return this.getKnownPowerState(light);
+      }
       streamDeck.logger.warn(
         `Failed to get live power state for ${light.name}, using cached state:`,
         error,
       );
-      return undefined;
+      return this.getKnownPowerState(light);
     }
   }
 
@@ -965,5 +1150,60 @@ export class ActionServices {
       throw new Error("Light repository not initialized");
     }
     return this.lightRepository.getToggleFeatures(deviceId);
+  }
+
+  private getLiveStateKey(light: Light, operation: string): string {
+    return `${light.deviceId}|${light.model}|${operation}`;
+  }
+
+  private isLiveStateTemporarilyBlocked(
+    light: Light,
+    operation: string,
+  ): boolean {
+    const blockedUntil = ActionServices.liveStateBlockedUntil.get(
+      this.getLiveStateKey(light, operation),
+    );
+    return typeof blockedUntil === "number" && blockedUntil > Date.now();
+  }
+
+  private clearLiveStateBlock(light: Light, operation: string): void {
+    const key = this.getLiveStateKey(light, operation);
+    ActionServices.liveStateBlockedUntil.delete(key);
+    ActionServices.liveStateLogged.delete(key);
+  }
+
+  private blockLiveState(
+    light: Light,
+    operation: string,
+    retryAfterMs: number,
+    error: unknown,
+  ): void {
+    const logKey = this.getLiveStateKey(light, operation);
+    ActionServices.liveStateBlockedUntil.set(logKey, Date.now() + retryAfterMs);
+    if (!ActionServices.liveStateLogged.has(logKey)) {
+      ActionServices.liveStateLogged.add(logKey);
+      streamDeck.logger.warn("light.live-state.temporarily-disabled", {
+        deviceId: light.deviceId,
+        model: light.model,
+        name: light.name,
+        operation,
+        retryAfterMs,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
+  private handleIgnorableLiveStateError(
+    light: Light,
+    error: unknown,
+    operation: string,
+  ): boolean {
+    if (!isIgnorableLiveStateError(error)) {
+      return false;
+    }
+
+    this.blockLiveState(light, operation, LIVE_STATE_RETRY_BACKOFF_MS, error);
+
+    return true;
   }
 }

--- a/src/backend/actions/shared/BaseDialAction.ts
+++ b/src/backend/actions/shared/BaseDialAction.ts
@@ -27,8 +27,14 @@ export type BaseDialSettings = BaseSettings & {
 export abstract class BaseDialAction<
   TSettings extends BaseDialSettings,
 > extends SingletonAction<TSettings> {
+  private static readonly LIVE_SYNC_INTERVAL_MS = 3000;
+
   protected services = new ActionServices();
   protected powerMap = new Map<string, boolean>();
+  private visibleActions = new Map<string, DialAction<TSettings & JsonObject>>();
+  private settingsMap = new Map<string, TSettings>();
+  private liveSyncTimers = new Map<string, ReturnType<typeof setInterval>>();
+  private liveSyncInFlight = new Set<string>();
 
   // ── Lifecycle ──────────────────────────────────────────────────
 
@@ -36,12 +42,14 @@ export abstract class BaseDialAction<
     const ctx = ev.action.id;
     if (!this.powerMap.has(ctx)) this.powerMap.set(ctx, true);
     this.initValueMaps(ctx);
-
-    await this.syncLiveState(ctx, ev.payload.settings);
-    await this.updateDisplay(
+    this.visibleActions.set(
+      ctx,
       ev.action as DialAction<TSettings & JsonObject>,
-      ev.payload.settings,
     );
+    this.settingsMap.set(ctx, ev.payload.settings);
+
+    await this.refreshVisibleDial(ctx);
+    this.startLiveSync(ctx);
   }
 
   override async onWillDisappear(
@@ -50,16 +58,23 @@ export abstract class BaseDialAction<
     const ctx = ev.action.id;
     this.powerMap.delete(ctx);
     this.cleanupValueMaps(ctx);
+    this.visibleActions.delete(ctx);
+    this.settingsMap.delete(ctx);
+    this.stopLiveSync(ctx);
+    this.liveSyncInFlight.delete(ctx);
     this.services.cleanupDialTimers(ctx);
   }
 
   override async onDidReceiveSettings(
     ev: DidReceiveSettingsEvent<TSettings>,
   ): Promise<void> {
-    await this.updateDisplay(
+    const ctx = ev.action.id;
+    this.visibleActions.set(
+      ctx,
       ev.action as DialAction<TSettings & JsonObject>,
-      ev.payload.settings,
     );
+    this.settingsMap.set(ctx, ev.payload.settings);
+    await this.refreshVisibleDial(ctx);
   }
 
   // ── Dial press / touch → power toggle ─────────────────────────
@@ -175,5 +190,54 @@ export abstract class BaseDialAction<
     _ev: SendToPluginEvent<JsonValue, TSettings>,
   ): Promise<void> {
     // No-op by default
+  }
+
+  protected getCurrentSettings(ctx: string, fallback: TSettings): TSettings {
+    return this.settingsMap.get(ctx) ?? fallback;
+  }
+
+  private startLiveSync(ctx: string): void {
+    this.stopLiveSync(ctx);
+    this.liveSyncTimers.set(
+      ctx,
+      setInterval(() => {
+        void this.refreshVisibleDial(ctx);
+      }, BaseDialAction.LIVE_SYNC_INTERVAL_MS),
+    );
+  }
+
+  private stopLiveSync(ctx: string): void {
+    const timer = this.liveSyncTimers.get(ctx);
+    if (timer) clearInterval(timer);
+    this.liveSyncTimers.delete(ctx);
+  }
+
+  private async refreshVisibleDial(ctx: string): Promise<void> {
+    const action = this.visibleActions.get(ctx);
+    const settings = this.settingsMap.get(ctx);
+    if (!action || !settings) {
+      return;
+    }
+
+    if (
+      this.liveSyncInFlight.has(ctx) ||
+      this.services.isDialInteractionActive(ctx)
+    ) {
+      return;
+    }
+
+    this.liveSyncInFlight.add(ctx);
+
+    try {
+      await this.syncLiveState(ctx, settings);
+      await this.updateDisplay(action, settings);
+    } catch (error) {
+      streamDeck.logger.warn("dial.live-sync.failed", {
+        context: ctx,
+        error,
+      });
+    } finally {
+      this.liveSyncInFlight.delete(ctx);
+    }
   }
 }

--- a/src/backend/actions/shared/validation.ts
+++ b/src/backend/actions/shared/validation.ts
@@ -16,6 +16,22 @@ export function isValidationError(error: unknown): boolean {
 }
 
 /**
+ * Some devices return malformed state payloads for specific fields.
+ * Those failures should not be treated as fatal for UI refresh loops.
+ */
+export function isIgnorableLiveStateError(error: unknown): boolean {
+  if (!(error instanceof Error)) {
+    return false;
+  }
+
+  return (
+    error.message.includes(
+      "Color temperature must be between 1000K and 50000K, got 0K",
+    ) || error.message.includes("ID must be a positive integer")
+  );
+}
+
+/**
  * Valid toggle instance names accepted by the Govee API.
  * Only these are forwarded to the API — all others are rejected.
  */

--- a/src/backend/connectivity/cloud/CloudTransport.ts
+++ b/src/backend/connectivity/cloud/CloudTransport.ts
@@ -78,6 +78,9 @@ export class CloudTransport implements ITransport {
           device.capabilities.map((c) => c.instance),
         );
         const capTypes = new Set(device.capabilities.map((c) => c.type));
+        const colorTemperatureRange = this.extractColorTemperatureRange(
+          device.capabilities,
+        );
 
         return {
           deviceId: device.deviceId,
@@ -88,11 +91,24 @@ export class CloudTransport implements ITransport {
           controllable: device.controllable,
           retrievable: device.retrievable,
           supportedCommands: [...device.supportedCmds],
+          properties: colorTemperatureRange
+            ? {
+                colorTem: {
+                  range: {
+                    min: colorTemperatureRange.min,
+                    max: colorTemperatureRange.max,
+                    precision: colorTemperatureRange.precision,
+                  },
+                },
+              }
+            : undefined,
           capabilities: {
             power: true,
             brightness: capInstances.has("brightness"),
             color: capInstances.has("colorRgb"),
-            colorTemperature: capInstances.has("colorTemInKelvin"),
+            colorTemperature:
+              capInstances.has("colorTemperatureK") ||
+              capInstances.has("colorTemInKelvin"),
             scenes: capInstances.has("lightScene"),
             segmentedColor: capInstances.has("segmentedColorRgb"),
             musicMode: capInstances.has("musicMode"),
@@ -123,7 +139,7 @@ export class CloudTransport implements ITransport {
     const power = state.getPowerState();
     const brightness = state.getBrightness();
     const color = state.getColor();
-    const temperature = state.getColorTemperature();
+    const temperature = this.safeGetColorTemperature(state, deviceId, model);
 
     const lightState: LightState = {
       deviceId,
@@ -224,5 +240,61 @@ export class CloudTransport implements ITransport {
   private async getApiKey(): Promise<string | undefined> {
     const settings = await globalSettingsService.getApiKey();
     return settings;
+  }
+
+  private safeGetColorTemperature(
+    state: { getColorTemperature(): ColorTemperature | undefined },
+    deviceId: string,
+    model: string,
+  ): ColorTemperature | undefined {
+    try {
+      return state.getColorTemperature();
+    } catch (error) {
+      streamDeck.logger?.warn("cloud.state.invalid_color_temperature", {
+        deviceId,
+        model,
+        error,
+      });
+      return undefined;
+    }
+  }
+
+  private extractColorTemperatureRange(
+    capabilities: ReadonlyArray<{
+      type: string;
+      instance: string;
+      parameters?: {
+        range?: { min: number; max: number; precision?: number };
+        fields?: Array<{
+          fieldName: string;
+          range?: { min: number; max: number; precision?: number };
+        }>;
+      };
+    }>,
+  ): { min: number; max: number; precision?: number } | undefined {
+    for (const capability of capabilities) {
+      if (
+        capability.instance === "colorTemperatureK" &&
+        capability.parameters?.range
+      ) {
+        return capability.parameters.range;
+      }
+    }
+
+    for (const capability of capabilities) {
+      const fields = capability.parameters?.fields;
+      if (!Array.isArray(fields)) {
+        continue;
+      }
+
+      const colorTemperatureField = fields.find(
+        (field) => field.fieldName === "colorTemperatureK" && field.range,
+      );
+      if (colorTemperatureField?.range) {
+        return colorTemperatureField.range;
+      }
+    }
+
+    return undefined;
   }
 }

--- a/src/backend/infrastructure/repositories/EnhancedGoveeLightRepository.ts
+++ b/src/backend/infrastructure/repositories/EnhancedGoveeLightRepository.ts
@@ -358,9 +358,10 @@ export class EnhancedGoveeLightRepository implements ILightRepository {
           }
 
           // Extract color temperature if available
-          const colorTemperature = validatedState.getColorTemperature?.() as
-            | ColorTemperature
-            | undefined;
+          const colorTemperature = this.safeGetColorTemperature(
+            validatedState as { getColorTemperature?(): ColorTemperature | undefined },
+            light.name,
+          );
           if (colorTemperature) {
             newState.colorTemperature = colorTemperature;
             newState.color = undefined;
@@ -636,5 +637,20 @@ export class EnhancedGoveeLightRepository implements ILightRepository {
     this.apiCircuitBreaker.reset();
     this.deviceCircuitBreakers.forEach((breaker) => breaker.reset());
     streamDeck.logger.info("All circuit breakers reset");
+  }
+
+  private safeGetColorTemperature(
+    state: { getColorTemperature?(): ColorTemperature | undefined },
+    lightName: string,
+  ): ColorTemperature | undefined {
+    try {
+      return state.getColorTemperature?.();
+    } catch (error) {
+      streamDeck.logger.warn(
+        `Ignoring invalid color temperature in state response for ${lightName}`,
+        error,
+      );
+      return undefined;
+    }
   }
 }

--- a/src/backend/infrastructure/repositories/GoveeLightRepository.ts
+++ b/src/backend/infrastructure/repositories/GoveeLightRepository.ts
@@ -17,14 +17,17 @@ import { MusicModeMapper } from "../mappers/MusicModeMapper";
 import { MusicModeConfig } from "../../domain/value-objects/MusicModeConfig";
 import {
   isValidationError,
+  isIgnorableLiveStateError,
   VALID_TOGGLE_INSTANCES,
 } from "../../actions/shared/validation";
 import streamDeck from "@elgato/streamdeck";
 
 export class GoveeLightRepository implements ILightRepository {
   private client: GoveeClient;
+  private readonly apiKey: string;
 
   constructor(apiKey: string, enableRetries = true) {
+    this.apiKey = apiKey;
     this.client = new GoveeClient({
       apiKey,
       enableRetries,
@@ -330,7 +333,10 @@ export class GoveeLightRepository implements ILightRepository {
       }
 
       // Extract color temperature if available
-      const colorTemperature = deviceState.getColorTemperature();
+      const colorTemperature = this.safeGetColorTemperature(
+        deviceState,
+        light.name,
+      );
       if (colorTemperature) {
         newState.colorTemperature = colorTemperature;
         newState.color = undefined;
@@ -343,6 +349,13 @@ export class GoveeLightRepository implements ILightRepository {
           `State query response validation failed for ${light.name} - using cached state`,
         );
         return;
+      }
+      if (isIgnorableLiveStateError(error)) {
+        const recovered = await this.tryRecoverStateFromRawCapabilities(light);
+        if (recovered) {
+          return;
+        }
+        throw error;
       }
       streamDeck.logger.error(
         `Failed to get state for light ${light.name}:`,
@@ -724,5 +737,115 @@ export class GoveeLightRepository implements ILightRepository {
    */
   getServiceStats() {
     return this.client.getServiceStats();
+  }
+
+  private safeGetColorTemperature(
+    deviceState: { getColorTemperature(): ColorTemperature | undefined },
+    lightName: string,
+  ): ColorTemperature | undefined {
+    try {
+      return deviceState.getColorTemperature();
+    } catch (error) {
+      streamDeck.logger.warn(
+        `Ignoring invalid color temperature in state response for ${lightName}`,
+        error,
+      );
+      return undefined;
+    }
+  }
+
+  private async tryRecoverStateFromRawCapabilities(
+    light: Light,
+  ): Promise<boolean> {
+    try {
+      const response = await fetch("https://openapi.api.govee.com/router/api/v1/device/state", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "Govee-API-Key": this.apiKey,
+        },
+        body: JSON.stringify({
+          requestId: crypto.randomUUID(),
+          payload: {
+            sku: light.model,
+            device: light.deviceId,
+          },
+        }),
+      });
+
+      if (!response.ok) {
+        return false;
+      }
+
+      const payload = (await response.json()) as {
+        data?: { capabilities?: Array<Record<string, unknown>> };
+        payload?: { capabilities?: Array<Record<string, unknown>> };
+      };
+      const capabilities =
+        payload.data?.capabilities ?? payload.payload?.capabilities;
+      if (!Array.isArray(capabilities)) {
+        return false;
+      }
+
+      const nextState: Partial<LightState> = {};
+      let recovered = false;
+
+      for (const capability of capabilities) {
+        const instance = capability.instance;
+        const rawState =
+          typeof capability.state === "object" && capability.state !== null
+            ? (capability.state as { value?: unknown }).value
+            : undefined;
+
+        if (instance === "powerSwitch") {
+          nextState.isOn =
+            rawState === 1 || rawState === true || rawState === "on";
+          recovered = true;
+        } else if (instance === "brightness" && typeof rawState === "number") {
+          nextState.brightness = new Brightness(rawState);
+          recovered = true;
+        } else if (instance === "colorRgb" && typeof rawState === "number") {
+          nextState.color = ColorRgb.fromObject({
+            r: Math.floor(rawState / 65536) & 0xff,
+            g: Math.floor(rawState / 256) & 0xff,
+            b: rawState & 0xff,
+          });
+          nextState.colorTemperature = undefined;
+          recovered = true;
+        } else if (
+          instance === "colorTemperatureK" &&
+          typeof rawState === "number" &&
+          rawState >= 1000 &&
+          rawState <= 50000
+        ) {
+          nextState.colorTemperature = new ColorTemperature(rawState);
+          nextState.color = undefined;
+          recovered = true;
+        }
+      }
+
+      if (!recovered) {
+        return false;
+      }
+
+      if (typeof nextState.isOn !== "boolean") {
+        nextState.isOn = light.isOn;
+      }
+      if (typeof nextState.isOnline !== "boolean") {
+        nextState.isOnline = true;
+      }
+
+      light.updateState(nextState);
+      streamDeck.logger.warn(
+        `Recovered partial live state from raw capabilities for ${light.name}`,
+      );
+      return true;
+    } catch (error) {
+      streamDeck.logger.warn(
+        `Failed raw capability fallback for ${light.name}`,
+        error,
+      );
+      return false;
+    }
   }
 }

--- a/src/shared/types/lights.ts
+++ b/src/shared/types/lights.ts
@@ -29,6 +29,7 @@ export interface LightItem {
       range: {
         min: number;
         max: number;
+        precision?: number;
       };
     };
   };


### PR DESCRIPTION
# Pull Request

## Description

Adds live value display and shared state syncing for Stream Deck dial actions so brightness, hue, color temperature, and segment color dials reflect current light values more reliably across contexts.

This PR improves dial feedback, live refresh behavior, and state recovery when Govee API responses are incomplete or malformed. It also tightens color temperature handling for device-specific ranges and fixes segment dial interaction so segment updates use the current action settings rather than stale values.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] 🎨 Style/formatting changes (no code logic changes)
- [ ] ♻️ Code refactoring (no functional changes)
- [x] ⚡ Performance improvements
- [ ] 🧪 Test additions or modifications
- [ ] 🔧 Build/CI changes
- [ ] 🏗️ Infrastructure changes

## Related Issues

- Related to dial live state/value display issues
- Related to malformed Govee live-state handling for color temperature and power state

## Changes Made

- updates dial titles and feedback so brightness, hue, color temperature, and segment dials show their current values directly on the action
- adds periodic live refresh for visible dials with shared in-flight sync protection and cached light-state snapshots
- preserves dial state across page changes so actions do not reset back to stale defaults when revisited
- hardens live-state reads against malformed Govee API responses such as `0K` color temperature and invalid power-state payloads
- adds fallback recovery from raw capability payloads when standard state reads fail
- improves color temperature handling by reading device-specific min/max/precision values from cloud capability metadata
- fixes segment color dial behavior so rotate and press interactions use current settings and apply the selected segment color correctly
- reduces noisy retries for non-retryable control errors and temporarily backs off broken live-state paths

## Screenshots

Not included.

## Testing

### Test Environment

- **OS**: Windows
- **Stream Deck Version**: Not recorded
- **Plugin Version**: 2.1.3
- **Node.js Version**: 20+

### Test Cases

- [x] Unit tests pass (`npm test`)
- [x] Type checking passes (`npm run type-check`)
- [x] Linting passes (`npm run lint`)
- [x] Build succeeds (`npm run build`)
- [x] Plugin installs correctly
- [x] Plugin functions as expected in Stream Deck

### Manual Testing Performed

- [x] Light control functionality
- [x] Group management (create/edit/delete)
- [x] Property Inspector UI
- [x] Error handling
- [x] API key validation
- [x] State management
- [x] Other: Dial live refresh, page switching, color temperature range handling, segment dial interaction

## Performance Impact

- [x] Minimal performance impact

Live refresh was added for visible dial actions, but requests are shared where possible through snapshot caching and in-flight sync coalescing to reduce duplicate state reads.

## Breaking Changes

None.

## Checklist

### Code Quality

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

### Documentation

- [ ] I have updated the README.md if needed
- [ ] I have updated the CONTRIBUTING.md if needed
- [x] I have added/updated JSDoc comments for new/modified functions
- [ ] I have added/updated examples if applicable

### Backwards Compatibility

- [x] My changes maintain backwards compatibility
- [x] If breaking changes exist, I have documented them above
- [x] I have considered the impact on existing users

### Security

- [x] My changes do not introduce security vulnerabilities
- [x] I have not exposed sensitive information (API keys, credentials, etc.)
- [x] I have followed secure coding practices

## Additional Notes

`npm run build` succeeds.

`npm run type-check` still reports existing `TS1238` decorator signature errors from the current TypeScript / `@elgato/streamdeck` decorator typing setup. These warnings/errors were not introduced by this change set and remain a separate environment/configuration issue.

## Reviewer Guidelines

### For Reviewers

- [ ] Code quality and style
- [ ] Test coverage
- [ ] Documentation completeness
- [ ] Performance considerations
- [ ] Security implications
- [ ] Backwards compatibility
- [ ] Manual testing (if UI changes)

---

**Thank you for contributing to Govee Light Management! 🚀**
