### PR TITLE
fix: clear gradient/nightlight overlays before solid-color commands (#170)

### DIFF
--- a/src/backend/actions/BrightnessAction.ts
+++ b/src/backend/actions/BrightnessAction.ts
@@ -57,6 +57,15 @@ export class BrightnessAction extends SingletonAction<BrightnessSettings> {
       const brightness = new Brightness(settings.brightnessValue ?? 50);
       const stopSpinner = this.services.showSpinner(ev.action);
       try {
+        // Exit gradient/nightlight overlay once per key session so
+        // setBrightness is not applied relative to a scene's dynamic
+        // brightness (see #170).
+        if (target.type === "light" && target.light) {
+          await this.services.ensurePreparedForSolidColor(
+            ev.action.id,
+            target.light,
+          );
+        }
         await this.services.controlTarget(target, "brightness", brightness);
       } finally {
         stopSpinner();

--- a/src/backend/actions/BrightnessDialAction.ts
+++ b/src/backend/actions/BrightnessDialAction.ts
@@ -46,6 +46,12 @@ export class BrightnessDialAction extends BaseDialAction<BrightnessDialSettings>
         await this.services.ensureServices(apiKey);
         const target = await this.services.resolveTarget(settings);
         if (!target) return;
+        // Exit gradient/nightlight overlay once per dial session so
+        // setBrightness is not applied relative to a scene's dynamic
+        // brightness (see #170).
+        if (target.type === "light" && target.light) {
+          await this.services.ensurePreparedForSolidColor(ctx, target.light);
+        }
         const finalValue = this.brightnessMap.get(ctx) ?? next;
         await this.services.controlTarget(
           target,

--- a/src/backend/actions/ColorAction.ts
+++ b/src/backend/actions/ColorAction.ts
@@ -55,6 +55,14 @@ export class ColorAction extends SingletonAction<ColorSettings> {
       const color = ColorRgb.fromHex(settings.colorValue || "#ffffff");
       const stopSpinner = this.services.showSpinner(ev.action);
       try {
+        // Exit gradient/nightlight overlay once per key session so
+        // setColor is not tinted by a lingering mode (see #170).
+        if (target.type === "light" && target.light) {
+          await this.services.ensurePreparedForSolidColor(
+            ev.action.id,
+            target.light,
+          );
+        }
         await this.services.controlTarget(target, "color", color);
       } finally {
         stopSpinner();

--- a/src/backend/actions/ColorHueDialAction.ts
+++ b/src/backend/actions/ColorHueDialAction.ts
@@ -49,6 +49,11 @@ export class ColorHueDialAction extends BaseDialAction<ColorHueDialSettings> {
         await this.services.ensureServices(apiKey);
         const target = await this.services.resolveTarget(settings);
         if (!target) return;
+        // Exit gradient/nightlight overlay once per dial session so
+        // setColor is not tinted by a lingering mode (see #170).
+        if (target.type === "light" && target.light) {
+          await this.services.ensurePreparedForSolidColor(ctx, target.light);
+        }
         const finalHue = this.hueMap.get(ctx) ?? next;
         const saturation = clamp(settings.saturation ?? 100, 0, 100);
         const color = hsvToRgb(finalHue, saturation, 100);

--- a/src/backend/actions/ColorTempDialAction.ts
+++ b/src/backend/actions/ColorTempDialAction.ts
@@ -66,6 +66,11 @@ export class ColorTempDialAction extends BaseDialAction<ColorTempDialSettings> {
         await this.services.ensureServices(apiKey);
         const target = await this.services.resolveTarget(settings);
         if (!target) return;
+        // Exit gradient/nightlight overlay once per dial session so
+        // setColorTemperature is not tinted by a lingering mode (see #170).
+        if (target.type === "light" && target.light) {
+          await this.services.ensurePreparedForSolidColor(ctx, target.light);
+        }
         const finalKelvin = normalizeKelvin(
           this.tempMap.get(ctx) ?? next,
           range,

--- a/src/backend/actions/ColorTemperatureAction.ts
+++ b/src/backend/actions/ColorTemperatureAction.ts
@@ -82,6 +82,14 @@ export class ColorTemperatureAction extends SingletonAction<ColorTemperatureSett
 
       const stopSpinner = this.services.showSpinner(ev.action);
       try {
+        // Exit gradient/nightlight overlay once per key session so
+        // setColorTemperature is not tinted by a lingering mode (see #170).
+        if (target.type === "light" && target.light) {
+          await this.services.ensurePreparedForSolidColor(
+            ev.action.id,
+            target.light,
+          );
+        }
         await this.services.controlTarget(
           target,
           "colorTemperature",

--- a/src/backend/actions/shared/ActionServices.ts
+++ b/src/backend/actions/shared/ActionServices.ts
@@ -152,6 +152,15 @@ export class ActionServices {
   private static lightStateSnapshots = new Map<string, LightState>();
   private static lightStateSyncedAt = new Map<string, number>();
   private static liveStateSyncInFlight = new Map<string, Promise<boolean>>();
+  /**
+   * Tracks which (contextId, deviceId, model) tuples have already had
+   * their overlay modes (gradient / nightlight) cleared in this dial
+   * session. Keeps the 1st rotation / 1st keypress slightly slower while
+   * avoiding those toggles on every subsequent command. Cleared when the
+   * dial disappears or switches to a different device (see
+   * `clearPreparedForContext`).
+   */
+  private static preparedForSolidColor = new Set<string>();
 
   get lightRepository() {
     return ActionServices._shared.lightRepository;
@@ -1217,5 +1226,96 @@ export class ActionServices {
     this.blockLiveState(light, operation, LIVE_STATE_RETRY_BACKOFF_MS, error);
 
     return true;
+  }
+
+  // ── Overlay-mode preparation for solid-color commands ─────────────────
+  //
+  // On RGB IC / scene-capable lights, the device may currently be in a
+  // gradient or nightlight mode. A bare setColor / setColorTemperature /
+  // setBrightness command does not reliably exit those overlays, which
+  // causes the perceived color to be tinted or washed out. Before the
+  // first solid-color command of a dial session, we explicitly disable
+  // the overlays that the device advertises. Subsequent commands in the
+  // same session skip the prepare step to avoid per-tick API overhead.
+  //
+  // The tracking is keyed by `${contextId}|${deviceId}|${model}` so that:
+  //   • different dials for the same device don't share prepared state
+  //     (safe: extra prepare calls are fire-and-forget)
+  //   • switching the dial to a different device forces a re-prepare
+  //   • disappearing / reappearing the dial forces a re-prepare
+
+  private getPreparedKey(
+    contextId: string,
+    light: Pick<Light, "deviceId" | "model">,
+  ): string {
+    return `${contextId}|${light.deviceId}|${light.model}`;
+  }
+
+  /**
+   * Clear any mode overlays that would tint or override a solid color
+   * command. Fire-and-forget per capability — a failure in one toggle
+   * does not block the others or the subsequent color command.
+   *
+   * This is intentionally public so tests can invoke it directly.
+   */
+  async prepareForSolidColor(light: Light): Promise<void> {
+    const repo = this.lightRepository;
+    if (!repo) {
+      return;
+    }
+    const tasks: Array<Promise<void>> = [];
+    if (light.supportsGradient()) {
+      tasks.push(
+        repo.toggleGradient(light, false).catch((error) => {
+          streamDeck.logger?.debug(
+            `prepareForSolidColor: toggleGradient off failed for ${light.name}`,
+            error,
+          );
+        }),
+      );
+    }
+    if (light.supportsNightlight()) {
+      tasks.push(
+        repo.toggleNightlight(light, false).catch((error) => {
+          streamDeck.logger?.debug(
+            `prepareForSolidColor: toggleNightlight off failed for ${light.name}`,
+            error,
+          );
+        }),
+      );
+    }
+    await Promise.all(tasks);
+  }
+
+  /**
+   * Idempotent, per-context guarded version of `prepareForSolidColor`.
+   * Runs the prepare once per `(contextId, deviceId, model)` tuple until
+   * `clearPreparedForContext` is called. Safe to call on every command.
+   */
+  async ensurePreparedForSolidColor(
+    contextId: string,
+    light: Light,
+  ): Promise<void> {
+    const key = this.getPreparedKey(contextId, light);
+    if (ActionServices.preparedForSolidColor.has(key)) {
+      return;
+    }
+    await this.prepareForSolidColor(light);
+    ActionServices.preparedForSolidColor.add(key);
+  }
+
+  /**
+   * Drop all prepared-state entries for a context. Called from
+   * `onWillDisappear` / `onDidReceiveSettings` so that the next command
+   * on that dial re-issues the overlay-clearing toggles. Matches prefix
+   * so we drop entries for any device previously used by this context.
+   */
+  clearPreparedForContext(contextId: string): void {
+    const prefix = `${contextId}|`;
+    for (const key of ActionServices.preparedForSolidColor) {
+      if (key.startsWith(prefix)) {
+        ActionServices.preparedForSolidColor.delete(key);
+      }
+    }
   }
 }

--- a/src/backend/actions/shared/BaseDialAction.ts
+++ b/src/backend/actions/shared/BaseDialAction.ts
@@ -66,6 +66,9 @@ export abstract class BaseDialAction<
     this.stopLiveSync(ctx);
     this.liveSyncInFlight.delete(ctx);
     this.services.cleanupDialTimers(ctx);
+    // Force the next rotation to re-issue overlay-clearing toggles
+    // (see ActionServices.ensurePreparedForSolidColor / issue #170).
+    this.services.clearPreparedForContext(ctx);
   }
 
   override async onDidReceiveSettings(
@@ -77,6 +80,9 @@ export abstract class BaseDialAction<
       ev.action as DialAction<TSettings & JsonObject>,
     );
     this.settingsMap.set(ctx, ev.payload.settings);
+    // Settings may have pointed the dial at a different device; re-prepare
+    // the newly-selected target on the next rotation.
+    this.services.clearPreparedForContext(ctx);
     await this.refreshVisibleDial(ctx);
   }
 

--- a/test/backend/actions/shared/ActionServices.test.ts
+++ b/test/backend/actions/shared/ActionServices.test.ts
@@ -1,5 +1,63 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ActionServices } from "../../../../src/backend/actions/shared/ActionServices";
+import { Light } from "../../../../src/backend/domain/entities/Light";
+import type { LightState } from "../../../../src/backend/domain/value-objects/LightState";
+
+const makeLight = (opts: {
+  deviceId?: string;
+  model?: string;
+  gradient?: boolean;
+  nightlight?: boolean;
+} = {}) =>
+  Light.create(
+    opts.deviceId ?? "dev-1",
+    opts.model ?? "H6001",
+    "Test Light",
+    { isOn: true, isOnline: true } as LightState,
+    {
+      brightness: true,
+      color: true,
+      colorTemperature: true,
+      scenes: false,
+      segmentedColor: false,
+      musicMode: false,
+      nightlight: opts.nightlight ?? false,
+      gradient: opts.gradient ?? false,
+    },
+  );
+
+/**
+ * ActionServices keeps its repository as a static shared instance. For
+ * tests we reach in and swap it out with a mock, and restore afterwards.
+ */
+const mockRepo = () => ({
+  toggleGradient: vi.fn().mockResolvedValue(undefined),
+  toggleNightlight: vi.fn().mockResolvedValue(undefined),
+});
+
+const installMockRepo = (repo: ReturnType<typeof mockRepo>) => {
+  // The _shared field is private; cast to unknown then a minimal interface.
+  const shared = (ActionServices as unknown as { _shared: { lightRepository?: unknown } })._shared;
+  const original = shared.lightRepository;
+  shared.lightRepository = repo;
+  return () => {
+    shared.lightRepository = original;
+  };
+};
+
+/**
+ * ActionServices.preparedForSolidColor is a private static Set that
+ * persists across test cases. Clear it between tests so each one starts
+ * from a clean state.
+ */
+const resetPreparedForSolidColor = () => {
+  const prepared = (
+    ActionServices as unknown as {
+      preparedForSolidColor: Set<string>;
+    }
+  ).preparedForSolidColor;
+  prepared.clear();
+};
 
 describe("ActionServices.isDialInteractionActive", () => {
   let services: ActionServices;
@@ -66,5 +124,152 @@ describe("ActionServices.isDialInteractionActive", () => {
 
     expect(first).not.toHaveBeenCalled();
     expect(second).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("ActionServices.prepareForSolidColor", () => {
+  it("toggles gradient off when the light advertises gradient capability", async () => {
+    const repo = mockRepo();
+    const restore = installMockRepo(repo);
+    try {
+      const services = new ActionServices();
+      const light = makeLight({ gradient: true });
+
+      await services.prepareForSolidColor(light);
+
+      expect(repo.toggleGradient).toHaveBeenCalledWith(light, false);
+      expect(repo.toggleNightlight).not.toHaveBeenCalled();
+    } finally {
+      restore();
+    }
+  });
+
+  it("toggles nightlight off when the light advertises nightlight capability", async () => {
+    const repo = mockRepo();
+    const restore = installMockRepo(repo);
+    try {
+      const services = new ActionServices();
+      const light = makeLight({ nightlight: true });
+
+      await services.prepareForSolidColor(light);
+
+      expect(repo.toggleNightlight).toHaveBeenCalledWith(light, false);
+      expect(repo.toggleGradient).not.toHaveBeenCalled();
+    } finally {
+      restore();
+    }
+  });
+
+  it("issues no toggle calls when the light supports none of the overlay modes", async () => {
+    const repo = mockRepo();
+    const restore = installMockRepo(repo);
+    try {
+      const services = new ActionServices();
+      const light = makeLight({});
+
+      await services.prepareForSolidColor(light);
+
+      expect(repo.toggleGradient).not.toHaveBeenCalled();
+      expect(repo.toggleNightlight).not.toHaveBeenCalled();
+    } finally {
+      restore();
+    }
+  });
+
+  it("swallows per-toggle failures so one failure does not block the others", async () => {
+    const repo = {
+      toggleGradient: vi.fn().mockRejectedValue(new Error("gradient failed")),
+      toggleNightlight: vi.fn().mockResolvedValue(undefined),
+    };
+    const restore = installMockRepo(repo);
+    try {
+      const services = new ActionServices();
+      const light = makeLight({ gradient: true, nightlight: true });
+
+      await expect(services.prepareForSolidColor(light)).resolves.toBeUndefined();
+      expect(repo.toggleGradient).toHaveBeenCalled();
+      expect(repo.toggleNightlight).toHaveBeenCalled();
+    } finally {
+      restore();
+    }
+  });
+});
+
+describe("ActionServices.ensurePreparedForSolidColor", () => {
+  beforeEach(() => {
+    resetPreparedForSolidColor();
+  });
+
+  it("issues the overlay toggles once per (context, device) tuple", async () => {
+    const repo = mockRepo();
+    const restore = installMockRepo(repo);
+    try {
+      const services = new ActionServices();
+      const light = makeLight({ gradient: true });
+
+      await services.ensurePreparedForSolidColor("ctx-1", light);
+      await services.ensurePreparedForSolidColor("ctx-1", light);
+      await services.ensurePreparedForSolidColor("ctx-1", light);
+
+      expect(repo.toggleGradient).toHaveBeenCalledTimes(1);
+    } finally {
+      restore();
+    }
+  });
+
+  it("re-issues toggles after clearPreparedForContext for the same context", async () => {
+    const repo = mockRepo();
+    const restore = installMockRepo(repo);
+    try {
+      const services = new ActionServices();
+      const light = makeLight({ gradient: true });
+
+      await services.ensurePreparedForSolidColor("ctx-1", light);
+      services.clearPreparedForContext("ctx-1");
+      await services.ensurePreparedForSolidColor("ctx-1", light);
+
+      expect(repo.toggleGradient).toHaveBeenCalledTimes(2);
+    } finally {
+      restore();
+    }
+  });
+
+  it("re-prepares when the context switches to a different device", async () => {
+    const repo = mockRepo();
+    const restore = installMockRepo(repo);
+    try {
+      const services = new ActionServices();
+      const lightA = makeLight({ deviceId: "dev-a", gradient: true });
+      const lightB = makeLight({ deviceId: "dev-b", gradient: true });
+
+      await services.ensurePreparedForSolidColor("ctx-1", lightA);
+      await services.ensurePreparedForSolidColor("ctx-1", lightB);
+
+      expect(repo.toggleGradient).toHaveBeenCalledTimes(2);
+      expect(repo.toggleGradient).toHaveBeenNthCalledWith(1, lightA, false);
+      expect(repo.toggleGradient).toHaveBeenNthCalledWith(2, lightB, false);
+    } finally {
+      restore();
+    }
+  });
+
+  it("isolates prepared state between different contexts", async () => {
+    const repo = mockRepo();
+    const restore = installMockRepo(repo);
+    try {
+      const services = new ActionServices();
+      const light = makeLight({ gradient: true });
+
+      await services.ensurePreparedForSolidColor("ctx-a", light);
+      await services.ensurePreparedForSolidColor("ctx-b", light);
+      // Clearing ctx-a must not affect ctx-b's prepared state.
+      services.clearPreparedForContext("ctx-a");
+      await services.ensurePreparedForSolidColor("ctx-b", light);
+
+      // 2 prepares: once for ctx-a, once for ctx-b. The ctx-b re-call is a no-op.
+      expect(repo.toggleGradient).toHaveBeenCalledTimes(2);
+    } finally {
+      restore();
+    }
   });
 });


### PR DESCRIPTION
## Summary

Fixes #170. RGB IC lights in active gradient or nightlight modes don't reliably exit those overlays when we send a bare `setColor` / `setColorTemperature` / `setBrightness`. The command succeeds at the API but the overlay continues to render, producing tinted output.

This was verified during live testing of #168 — the plugin was sending the mathematically correct pure red `0xFF0000`, but the physical light displayed a tinted/washed-out color because a scene overlay remained active.

## Change

Before the first solid-color command of a dial-session (or key-press session), explicitly toggle off the overlay capabilities the device advertises. Subsequent commands in the same session skip the prepare step to avoid API overhead.

### New in `ActionServices`

- `prepareForSolidColor(light)` — fire-and-forget per capability. A failing toggle doesn't block the others or the subsequent color command.
- `ensurePreparedForSolidColor(contextId, light)` — guarded once-per-session version, keyed by `${ctx}|${deviceId}|${model}`.
- `clearPreparedForContext(contextId)` — drop entries for a context.

### Wired into

| Action | Trigger point |
|---|---|
| `ColorHueDialAction` | `onDialRotate` deferred callback |
| `ColorTempDialAction` | `onDialRotate` deferred callback |
| `BrightnessDialAction` | `onDialRotate` deferred callback |
| `ColorAction` (keypad) | `onKeyDown` |
| `ColorTemperatureAction` (keypad) | `onKeyDown` |
| `BrightnessAction` (keypad) | `onKeyDown` |

### BaseDialAction lifecycle

`onWillDisappear` and `onDidReceiveSettings` now call `clearPreparedForContext` so the next rotation re-primes. This handles the case where the Property Inspector points the dial at a different device.

## Out of scope

- **Groups**: `controlGroup` iterates internally; guarding it cleanly would require per-light prepare in the group path. The helper operates on a single `Light`. Tracked as follow-up if user reports issues.
- **DreamView**: not in `LightCapabilities` yet. Can be added once `CloudTransport` discovery wires the `dreamViewToggle` instance through. Small scope, can follow up.

## Test plan

- [x] `npm run type-check` — passes
- [x] `npm run lint` — passes
- [x] `npm run build` — passes
- [x] `npm run test` — 289 → 297 passing (+8)

New tests cover:
1. Toggle dispatch by capability (gradient / nightlight / both / neither)
2. Fire-and-forget tolerance of one failing toggle
3. Once-per-`(context, device)` semantics
4. Re-prepare after `clearPreparedForContext`
5. Re-prepare on device switch within the same context
6. Context isolation (clearing ctx-a leaves ctx-b intact)

Fixes #170