### PR TITLE
feat: add Snapshot action to recall saved light presets (#174)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,7 +85,7 @@ src/
 
 ### Core Components
 
-- **Entry point**: `src/backend/plugin.ts` - Registers 13 actions (8 keypad + 5 encoder)
+- **Entry point**: `src/backend/plugin.ts` - Registers 14 actions (9 keypad + 5 encoder)
 - **Actions**: Located in `src/backend/actions/` directory
   - **Keypad Actions:**
     - `OnOffAction.ts` - Power toggle/on/off with state sync on appear

--- a/com.felixgeelhaar.govee-light-management.sdPlugin/imgs/actions/snapshot/icon.svg
+++ b/com.felixgeelhaar.govee-light-management.sdPlugin/imgs/actions/snapshot/icon.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 288 288"><g fill="none" stroke="#ffffff" stroke-width="14" stroke-linecap="round" stroke-linejoin="round">
+<rect x="64" y="56" width="160" height="176" rx="16"/>
+<path d="M 104 56 L 104 40 L 184 40 L 184 56"/>
+<line x1="104" y1="108" x2="184" y2="108"/>
+<line x1="104" y1="148" x2="164" y2="148"/>
+<line x1="104" y1="188" x2="144" y2="188"/>
+</g>
+<circle cx="184" cy="188" r="8" fill="#ffffff"/>
+</svg>

--- a/com.felixgeelhaar.govee-light-management.sdPlugin/imgs/actions/snapshot/key.svg
+++ b/com.felixgeelhaar.govee-light-management.sdPlugin/imgs/actions/snapshot/key.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 288 288"><g fill="none" stroke="#ffffff" stroke-width="14" stroke-linecap="round" stroke-linejoin="round">
+<rect x="64" y="56" width="160" height="176" rx="16"/>
+<path d="M 104 56 L 104 40 L 184 40 L 184 56"/>
+<line x1="104" y1="108" x2="184" y2="108"/>
+<line x1="104" y1="148" x2="164" y2="148"/>
+<line x1="104" y1="188" x2="144" y2="188"/>
+</g>
+<circle cx="184" cy="188" r="8" fill="#ffffff"/>
+</svg>

--- a/com.felixgeelhaar.govee-light-management.sdPlugin/manifest.json
+++ b/com.felixgeelhaar.govee-light-management.sdPlugin/manifest.json
@@ -90,6 +90,20 @@
       ]
     },
     {
+      "Name": "Snapshot",
+      "UUID": "com.felixgeelhaar.govee-light-management.snapshot",
+      "Icon": "imgs/actions/snapshot/icon",
+      "Tooltip": "Recall a saved snapshot preset on a Govee light",
+      "PropertyInspectorPath": "ui/snapshot.html",
+      "Controllers": ["Keypad"],
+      "States": [
+        {
+          "Image": "imgs/actions/snapshot/key",
+          "TitleAlignment": "bottom"
+        }
+      ]
+    },
+    {
       "Name": "Music Mode",
       "UUID": "com.felixgeelhaar.govee-light-management.music-mode",
       "Icon": "imgs/actions/music-mode/icon",

--- a/com.felixgeelhaar.govee-light-management.sdPlugin/ui/snapshot.html
+++ b/com.felixgeelhaar.govee-light-management.sdPlugin/ui/snapshot.html
@@ -1,0 +1,72 @@
+<!doctype html>
+<html>
+  <head lang="en-gb">
+    <meta charset="utf-8" />
+    <title>Govee Light Management | Snapshot</title>
+    <link rel="stylesheet" href="./css/main.css" />
+    <script src="./js/sdpi-components.js"></script>
+    <script src="./js/setup.js"></script>
+  </head>
+  <body>
+    <div id="settings" class="hidden">
+      <sdpi-item label="Device">
+        <sdpi-select
+          id="deviceSelect"
+          setting="selectedDeviceId"
+          placeholder=""
+          datasource="getDevices"
+          show-refresh
+          label-setting="selectedLightName"
+        ></sdpi-select>
+      </sdpi-item>
+
+      <sdpi-item label="Snapshot">
+        <sdpi-select
+          id="snapshotSelect"
+          setting="selectedSnapshot"
+          datasource="getSnapshots"
+          show-refresh
+          placeholder="Select a device first"
+        ></sdpi-select>
+      </sdpi-item>
+    </div>
+
+    <div id="setup" class="hidden">
+      <sdpi-item label="API Key">
+        <sdpi-password
+          id="apiKey"
+          global
+          setting="unverifiedApiKey"
+          placeholder="API key from Govee"
+        ></sdpi-password>
+      </sdpi-item>
+      <sdpi-item>
+        <sdpi-button id="connect">Connect</sdpi-button>
+        <div id="errorMessage" class="hidden">
+          Failed to connect, please try again.
+        </div>
+      </sdpi-item>
+      <sdpi-item label="Guide" class="guide">
+        <ol>
+          <li>Open the Govee app</li>
+          <li>Go to settings</li>
+          <li>Select "Apply for API Key"</li>
+        </ol>
+      </sdpi-item>
+    </div>
+
+    <script>
+      document.addEventListener("DOMContentLoaded", () => {
+        const deviceSelect = document.getElementById("deviceSelect");
+        const snapshotSelect = document.getElementById("snapshotSelect");
+
+        // When device changes, refresh the snapshot list
+        deviceSelect.addEventListener("valuechange", () => {
+          if (snapshotSelect && snapshotSelect.refresh) {
+            snapshotSelect.refresh();
+          }
+        });
+      });
+    </script>
+  </body>
+</html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@elgato/streamdeck": "^2.0.4",
-        "@felixgeelhaar/govee-api-client": "^3.1.14",
+        "@felixgeelhaar/govee-api-client": "^3.2.0",
         "zod": "4.3.5"
       },
       "devDependencies": {
@@ -577,9 +577,9 @@
       }
     },
     "node_modules/@felixgeelhaar/govee-api-client": {
-      "version": "3.1.14",
-      "resolved": "https://registry.npmjs.org/@felixgeelhaar/govee-api-client/-/govee-api-client-3.1.14.tgz",
-      "integrity": "sha512-fBGIod9nUYveHeNw9rxQguq99zlehj1E55/X/On6xiM11j2fmU94SwaA7rUqsgS2zW6i3Fw/wJccw006kmT04Q==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@felixgeelhaar/govee-api-client/-/govee-api-client-3.2.0.tgz",
+      "integrity": "sha512-nJr4zjJ1S1y5ZMnNY9+s/s5GtpVK+Vdxco+YajoJdx2ovXZC2zjYJbGkODbt79V7/8VnKEixp9grWxhRhqwv/A==",
       "license": "MIT",
       "dependencies": {
         "axios": "1.15.0",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
   },
   "dependencies": {
     "@elgato/streamdeck": "^2.0.4",
-    "@felixgeelhaar/govee-api-client": "^3.1.14",
+    "@felixgeelhaar/govee-api-client": "^3.2.0",
     "zod": "4.3.5"
   },
   "overrides": {

--- a/src/backend/actions/SnapshotAction.ts
+++ b/src/backend/actions/SnapshotAction.ts
@@ -1,0 +1,187 @@
+import {
+  action,
+  KeyDownEvent,
+  SingletonAction,
+  WillAppearEvent,
+  WillDisappearEvent,
+  type DidReceiveSettingsEvent,
+  type SendToPluginEvent,
+  streamDeck,
+} from "@elgato/streamdeck";
+import type { JsonValue } from "@elgato/utils";
+import { Snapshot } from "@felixgeelhaar/govee-api-client";
+import {
+  ActionServices,
+  sendToPI,
+  type BaseSettings,
+} from "./shared/ActionServices";
+
+type SnapshotSettings = BaseSettings & {
+  selectedSnapshot?: string;
+};
+
+@action({ UUID: "com.felixgeelhaar.govee-light-management.snapshot" })
+export class SnapshotAction extends SingletonAction<SnapshotSettings> {
+  private services = new ActionServices();
+
+  override async onWillAppear(
+    ev: WillAppearEvent<SnapshotSettings>,
+  ): Promise<void> {
+    await ev.action.setTitle(this.getTitle(ev.payload.settings));
+  }
+
+  override onWillDisappear(_ev: WillDisappearEvent<SnapshotSettings>): void {
+    // No state to clean up
+  }
+
+  override async onDidReceiveSettings(
+    ev: DidReceiveSettingsEvent<SnapshotSettings>,
+  ): Promise<void> {
+    await ev.action.setTitle(this.getTitle(ev.payload.settings));
+  }
+
+  override async onKeyDown(ev: KeyDownEvent<SnapshotSettings>): Promise<void> {
+    const { settings } = ev.payload;
+
+    const apiKey = await this.services.getApiKey(settings);
+    if (!apiKey || !settings.selectedDeviceId) {
+      await ev.action.showAlert();
+      return;
+    }
+
+    await this.services.ensureServices(apiKey);
+    const target = await this.services.resolveTarget(settings);
+
+    if (!target) {
+      await ev.action.showAlert();
+      return;
+    }
+
+    if (!settings.selectedSnapshot) {
+      streamDeck.logger.warn("Snapshot action: no snapshot selected");
+      await ev.action.showAlert();
+      return;
+    }
+
+    try {
+      const parsed = JSON.parse(settings.selectedSnapshot) as {
+        id: number;
+        paramId: number;
+        name: string;
+      };
+      const snapshot = new Snapshot(parsed.id, parsed.paramId, parsed.name);
+
+      const stopSpinner = this.services.showSpinner(ev.action);
+      try {
+        if (target.type === "light" && target.light) {
+          await this.services.applySnapshot(target.light, snapshot);
+        } else if (target.type === "group" && target.group) {
+          // Apply snapshot to each light in the group.
+          // Groups don't have a single-call path for snapshots,
+          // so iterate the members sequentially.
+          for (const member of target.group.lights) {
+            try {
+              await this.services.applySnapshot(member, snapshot);
+            } catch (error) {
+              streamDeck.logger.warn(
+                `Snapshot apply failed for group member ${member.name}:`,
+                error,
+              );
+              // Continue to next light — don't fail the whole group
+            }
+          }
+        }
+      } finally {
+        stopSpinner();
+      }
+      await ev.action.showOk();
+    } catch (error) {
+      streamDeck.logger.error("Failed to apply snapshot:", error);
+      await ev.action.showAlert();
+    }
+  }
+
+  override async onSendToPlugin(
+    ev: SendToPluginEvent<JsonValue, SnapshotSettings>,
+  ): Promise<void> {
+    if (!(ev.payload instanceof Object) || !("event" in ev.payload)) return;
+
+    switch (ev.payload.event) {
+      case "getDevices":
+        await this.services.handleGetDevices(ev.action.id);
+        break;
+      case "getGroups":
+        await this.services.handleGetGroups(ev.action.id);
+        break;
+      case "saveGroup":
+        await this.services.handleSaveGroup(ev.action.id, ev.payload);
+        break;
+      case "deleteGroup":
+        await this.services.handleDeleteGroup(ev.action.id, ev.payload);
+        break;
+      case "refreshState":
+        await this.services.handleRefreshState();
+        break;
+      case "getSnapshots": {
+        const settings = await ev.action.getSettings();
+        await this.handleGetSnapshots(ev.action.id, settings);
+        break;
+      }
+    }
+  }
+
+  private async handleGetSnapshots(
+    actionId: string,
+    settings: SnapshotSettings,
+  ): Promise<void> {
+    const deviceId = settings.selectedDeviceId;
+    if (!deviceId) {
+      await sendToPI(actionId, { event: "getSnapshots", items: [] });
+      return;
+    }
+
+    try {
+      const apiKey = await this.services.getApiKey(settings ?? {});
+      if (!apiKey) {
+        await sendToPI(actionId, { event: "getSnapshots", items: [] });
+        return;
+      }
+
+      await this.services.ensureServices(apiKey);
+      const target = await this.services.resolveTarget({
+        selectedDeviceId: deviceId,
+      });
+
+      if (!target || target.type !== "light" || !target.light) {
+        await sendToPI(actionId, { event: "getSnapshots", items: [] });
+        return;
+      }
+
+      const snapshots = await this.services.getSnapshots(target.light);
+      await sendToPI(actionId, {
+        event: "getSnapshots",
+        items: snapshots.map((s) => ({
+          label: s.name,
+          value: JSON.stringify({
+            id: s.id,
+            paramId: s.paramId,
+            name: s.name,
+          }),
+        })),
+      });
+    } catch (error) {
+      streamDeck.logger.error("Failed to fetch snapshots:", error);
+      await sendToPI(actionId, { event: "getSnapshots", items: [] });
+    }
+  }
+
+  private getTitle(settings: SnapshotSettings): string {
+    if (!settings.selectedSnapshot) return "";
+    try {
+      const parsed = JSON.parse(settings.selectedSnapshot);
+      return parsed.name || "";
+    } catch {
+      return "";
+    }
+  }
+}

--- a/src/backend/actions/shared/ActionServices.ts
+++ b/src/backend/actions/shared/ActionServices.ts
@@ -15,6 +15,7 @@ import {
   ColorRgb,
   ColorTemperature,
   LightScene,
+  Snapshot,
   MusicMode,
 } from "@felixgeelhaar/govee-api-client";
 
@@ -960,6 +961,20 @@ export class ActionServices {
       throw new Error("Light repository not initialized");
     }
     await this.lightRepository.setLightScene(light, scene);
+  }
+
+  async getSnapshots(light: Light): Promise<Snapshot[]> {
+    if (!this.lightRepository) {
+      throw new Error("Light repository not initialized");
+    }
+    return this.lightRepository.getSnapshots(light);
+  }
+
+  async applySnapshot(light: Light, snapshot: Snapshot): Promise<void> {
+    if (!this.lightRepository) {
+      throw new Error("Light repository not initialized");
+    }
+    await this.lightRepository.applySnapshot(light, snapshot);
   }
 
   async toggleFeatureRaw(

--- a/src/backend/infrastructure/repositories/GoveeLightRepository.ts
+++ b/src/backend/infrastructure/repositories/GoveeLightRepository.ts
@@ -5,6 +5,7 @@ import {
   Brightness,
   GoveeDevice,
   LightScene,
+  Snapshot,
   MusicMode,
   SegmentColor as ApiSegmentColor,
 } from "@felixgeelhaar/govee-api-client";
@@ -425,6 +426,46 @@ export class GoveeLightRepository implements ILightRepository {
       );
       throw new Error(
         `Failed to get dynamic scenes: ${error instanceof Error ? error.message : "Unknown error"}`,
+      );
+    }
+  }
+
+  async getSnapshots(light: Light): Promise<Snapshot[]> {
+    try {
+      return await this.client.getSnapshots(light.deviceId, light.model);
+    } catch (error) {
+      if (isValidationError(error)) {
+        streamDeck.logger.warn(
+          `Snapshots fetch validation failed for ${light.name}`,
+        );
+        return [];
+      }
+      streamDeck.logger.error(
+        `Failed to get snapshots for ${light.name}:`,
+        error,
+      );
+      throw new Error(
+        `Failed to get snapshots: ${error instanceof Error ? error.message : "Unknown error"}`,
+      );
+    }
+  }
+
+  async applySnapshot(light: Light, snapshot: Snapshot): Promise<void> {
+    try {
+      await this.client.setSnapshot(light.deviceId, light.model, snapshot);
+    } catch (error) {
+      if (isValidationError(error)) {
+        streamDeck.logger.warn(
+          `Snapshot command sent but response validation failed for ${light.name}`,
+        );
+        return;
+      }
+      streamDeck.logger.error(
+        `Failed to apply snapshot for ${light.name}:`,
+        error,
+      );
+      throw new Error(
+        `Failed to apply snapshot: ${error instanceof Error ? error.message : "Unknown error"}`,
       );
     }
   }

--- a/src/backend/plugin.ts
+++ b/src/backend/plugin.ts
@@ -11,6 +11,7 @@ import { SaturationDialAction } from "./actions/SaturationDialAction";
 import { SegmentColorAction } from "./actions/SegmentColorAction";
 import { SegmentColorDialAction } from "./actions/SegmentColorDialAction";
 import { SceneAction } from "./actions/SceneAction";
+import { SnapshotAction } from "./actions/SnapshotAction";
 import { MusicModeAction } from "./actions/MusicModeAction";
 import { ToggleAction } from "./actions/ToggleAction";
 
@@ -23,6 +24,7 @@ streamDeck.actions.registerAction(new ColorAction());
 streamDeck.actions.registerAction(new ColorTemperatureAction());
 streamDeck.actions.registerAction(new SegmentColorAction());
 streamDeck.actions.registerAction(new SceneAction());
+streamDeck.actions.registerAction(new SnapshotAction());
 streamDeck.actions.registerAction(new MusicModeAction());
 streamDeck.actions.registerAction(new ToggleAction());
 


### PR DESCRIPTION
## Summary

Closes #174. Adds a **Snapshot** keypad action so users can recall their Govee-app-saved presets (static light states like "Reading", "Movie night", "Gaming RGB") with a single Stream Deck press.

**Requested by @PnnnG in #162.** Previously, recalling a snapshot required opening the Govee mobile app.

## What are snapshots?

| Feature | Type | Creator |
|---|---|---|
| `lightScene` | Dynamic animations | Govee firmware (curated) |
| `diyScene` | Dynamic animations | User (Govee app) |
| **`snapshot`** | Static preset slot | User (Govee app) |

Snapshots are point-in-time configurations the user saves in the Govee app. This action exposes them as Stream Deck keys.

## Changes

### Upstream dependency
Bumps `@felixgeelhaar/govee-api-client` from 3.1.14 to **3.2.0** ([govee-api-client#24](https://github.com/felixgeelhaar/govee-api-client/pull/24)), which adds `Snapshot` / `DiyScene` value objects, commands, and the full query/set API surface.

### Plugin
- **`SnapshotAction`** (keypad) — follows `SceneAction` pattern:
  - PI: device dropdown + dynamic snapshot dropdown (`datasource: getSnapshots`, refreshes on device change)
  - Title: snapshot name
  - onKeyDown: resolves target, applies snapshot
  - **Group support**: iterates group members, applies snapshot to each (fire-and-forget per light)
- **`GoveeLightRepository`**: `getSnapshots(light)` / `applySnapshot(light, snapshot)`
- **`ActionServices`**: delegates for both
- Manifest, PI HTML, icon/key SVGs, CLAUDE.md action count (13 → 14)

## Test plan

- [x] `npm run type-check`
- [x] `npm run lint`
- [x] `npm run build`
- [x] `npm run streamdeck:validate`
- [x] `npm run test` — 308 tests passing

## Note on testing

Snapshot activation requires a Govee account with saved snapshots. Users who have none will see an empty dropdown (gracefully handled — the action shows alert on press with no snapshot selected). Hardware testing requires a device with user-created snapshots in the Govee app.

Closes #174