### PR TITLE
fix: clear overlay modes for group targets (#170)

### DIFF
--- a/src/backend/actions/BrightnessAction.ts
+++ b/src/backend/actions/BrightnessAction.ts
@@ -57,15 +57,8 @@ export class BrightnessAction extends SingletonAction<BrightnessSettings> {
       const brightness = new Brightness(settings.brightnessValue ?? 50);
       const stopSpinner = this.services.showSpinner(ev.action);
       try {
-        // Exit gradient/nightlight overlay once per key session so
-        // setBrightness is not applied relative to a scene's dynamic
-        // brightness (see #170).
-        if (target.type === "light" && target.light) {
-          await this.services.ensurePreparedForSolidColor(
-            ev.action.id,
-            target.light,
-          );
-        }
+        // Clear overlay modes for single lights and groups (see #170).
+        await this.services.ensurePreparedForTarget(ev.action.id, target);
         await this.services.controlTarget(target, "brightness", brightness);
       } finally {
         stopSpinner();

--- a/src/backend/actions/BrightnessDialAction.ts
+++ b/src/backend/actions/BrightnessDialAction.ts
@@ -46,12 +46,8 @@ export class BrightnessDialAction extends BaseDialAction<BrightnessDialSettings>
         await this.services.ensureServices(apiKey);
         const target = await this.services.resolveTarget(settings);
         if (!target) return;
-        // Exit gradient/nightlight overlay once per dial session so
-        // setBrightness is not applied relative to a scene's dynamic
-        // brightness (see #170).
-        if (target.type === "light" && target.light) {
-          await this.services.ensurePreparedForSolidColor(ctx, target.light);
-        }
+        // Clear overlay modes for single lights and groups (see #170).
+        await this.services.ensurePreparedForTarget(ctx, target);
         const finalValue = this.brightnessMap.get(ctx) ?? next;
         await this.services.controlTarget(
           target,

--- a/src/backend/actions/ColorAction.ts
+++ b/src/backend/actions/ColorAction.ts
@@ -55,14 +55,8 @@ export class ColorAction extends SingletonAction<ColorSettings> {
       const color = ColorRgb.fromHex(settings.colorValue || "#ffffff");
       const stopSpinner = this.services.showSpinner(ev.action);
       try {
-        // Exit gradient/nightlight overlay once per key session so
-        // setColor is not tinted by a lingering mode (see #170).
-        if (target.type === "light" && target.light) {
-          await this.services.ensurePreparedForSolidColor(
-            ev.action.id,
-            target.light,
-          );
-        }
+        // Clear overlay modes for single lights and groups (see #170).
+        await this.services.ensurePreparedForTarget(ev.action.id, target);
         await this.services.controlTarget(target, "color", color);
       } finally {
         stopSpinner();

--- a/src/backend/actions/ColorHueDialAction.ts
+++ b/src/backend/actions/ColorHueDialAction.ts
@@ -49,11 +49,8 @@ export class ColorHueDialAction extends BaseDialAction<ColorHueDialSettings> {
         await this.services.ensureServices(apiKey);
         const target = await this.services.resolveTarget(settings);
         if (!target) return;
-        // Exit gradient/nightlight overlay once per dial session so
-        // setColor is not tinted by a lingering mode (see #170).
-        if (target.type === "light" && target.light) {
-          await this.services.ensurePreparedForSolidColor(ctx, target.light);
-        }
+        // Clear overlay modes for single lights and groups (see #170).
+        await this.services.ensurePreparedForTarget(ctx, target);
         const finalHue = this.hueMap.get(ctx) ?? next;
         const saturation = clamp(settings.saturation ?? 100, 0, 100);
         const color = hsvToRgb(finalHue, saturation, 100);

--- a/src/backend/actions/ColorTempDialAction.ts
+++ b/src/backend/actions/ColorTempDialAction.ts
@@ -66,11 +66,8 @@ export class ColorTempDialAction extends BaseDialAction<ColorTempDialSettings> {
         await this.services.ensureServices(apiKey);
         const target = await this.services.resolveTarget(settings);
         if (!target) return;
-        // Exit gradient/nightlight overlay once per dial session so
-        // setColorTemperature is not tinted by a lingering mode (see #170).
-        if (target.type === "light" && target.light) {
-          await this.services.ensurePreparedForSolidColor(ctx, target.light);
-        }
+        // Clear overlay modes for single lights and groups (see #170).
+        await this.services.ensurePreparedForTarget(ctx, target);
         const finalKelvin = normalizeKelvin(
           this.tempMap.get(ctx) ?? next,
           range,

--- a/src/backend/actions/ColorTemperatureAction.ts
+++ b/src/backend/actions/ColorTemperatureAction.ts
@@ -82,14 +82,8 @@ export class ColorTemperatureAction extends SingletonAction<ColorTemperatureSett
 
       const stopSpinner = this.services.showSpinner(ev.action);
       try {
-        // Exit gradient/nightlight overlay once per key session so
-        // setColorTemperature is not tinted by a lingering mode (see #170).
-        if (target.type === "light" && target.light) {
-          await this.services.ensurePreparedForSolidColor(
-            ev.action.id,
-            target.light,
-          );
-        }
+        // Clear overlay modes for single lights and groups (see #170).
+        await this.services.ensurePreparedForTarget(ev.action.id, target);
         await this.services.controlTarget(
           target,
           "colorTemperature",

--- a/src/backend/actions/SaturationDialAction.ts
+++ b/src/backend/actions/SaturationDialAction.ts
@@ -66,11 +66,8 @@ export class SaturationDialAction extends BaseDialAction<SaturationDialSettings>
         await this.services.ensureServices(apiKey);
         const target = await this.services.resolveTarget(settings);
         if (!target) return;
-        // Exit gradient/nightlight overlay once per dial session so
-        // setColor is not tinted by a lingering mode (see #170).
-        if (target.type === "light" && target.light) {
-          await this.services.ensurePreparedForSolidColor(ctx, target.light);
-        }
+        // Clear overlay modes for single lights and groups (see #170).
+        await this.services.ensurePreparedForTarget(ctx, target);
         const hue = this.hueMap.get(ctx) ?? 0;
         const saturation = this.saturationMap.get(ctx) ?? next;
         const color = hsvToRgb(hue, saturation, 100);

--- a/src/backend/actions/shared/ActionServices.ts
+++ b/src/backend/actions/shared/ActionServices.ts
@@ -1320,6 +1320,25 @@ export class ActionServices {
   }
 
   /**
+   * Convenience wrapper that handles both single-light and group targets.
+   * For groups, iterates the controllable lights and prepares each one.
+   * Replaces the per-action `if (target.type === "light")` check so
+   * call sites can pass the target directly.
+   */
+  async ensurePreparedForTarget(
+    contextId: string,
+    target: DeviceTarget,
+  ): Promise<void> {
+    if (target.type === "light" && target.light) {
+      await this.ensurePreparedForSolidColor(contextId, target.light);
+    } else if (target.type === "group" && target.group) {
+      for (const light of target.group.getControllableLights()) {
+        await this.ensurePreparedForSolidColor(contextId, light);
+      }
+    }
+  }
+
+  /**
    * Drop all prepared-state entries for a context. Called from
    * `onWillDisappear` / `onDidReceiveSettings` so that the next command
    * on that dial re-issues the overlay-clearing toggles. Matches prefix

--- a/test/backend/actions/shared/ActionServices.test.ts
+++ b/test/backend/actions/shared/ActionServices.test.ts
@@ -273,3 +273,79 @@ describe("ActionServices.ensurePreparedForSolidColor", () => {
     }
   });
 });
+
+describe("ActionServices.ensurePreparedForTarget", () => {
+  beforeEach(() => {
+    resetPreparedForSolidColor();
+  });
+
+  it("prepares a single-light target", async () => {
+    const repo = mockRepo();
+    const restore = installMockRepo(repo);
+    try {
+      const services = new ActionServices();
+      const light = makeLight({ gradient: true });
+
+      await services.ensurePreparedForTarget("ctx-1", {
+        type: "light",
+        light,
+      });
+
+      expect(repo.toggleGradient).toHaveBeenCalledWith(light, false);
+    } finally {
+      restore();
+    }
+  });
+
+  it("prepares each controllable light in a group target", async () => {
+    const repo = mockRepo();
+    const restore = installMockRepo(repo);
+    try {
+      const services = new ActionServices();
+      const lightA = makeLight({
+        deviceId: "grp-a",
+        gradient: true,
+        nightlight: true,
+      });
+      const lightB = makeLight({
+        deviceId: "grp-b",
+        gradient: true,
+      });
+
+      // Minimal LightGroup stub — only getControllableLights is called.
+      const group = {
+        getControllableLights: () => [lightA, lightB],
+      } as unknown as import("../../../../src/backend/domain/entities/LightGroup").LightGroup;
+
+      await services.ensurePreparedForTarget("ctx-1", {
+        type: "group",
+        group,
+      });
+
+      expect(repo.toggleGradient).toHaveBeenCalledTimes(2);
+      expect(repo.toggleGradient).toHaveBeenNthCalledWith(1, lightA, false);
+      expect(repo.toggleGradient).toHaveBeenNthCalledWith(2, lightB, false);
+      expect(repo.toggleNightlight).toHaveBeenCalledTimes(1);
+      expect(repo.toggleNightlight).toHaveBeenCalledWith(lightA, false);
+    } finally {
+      restore();
+    }
+  });
+
+  it("is a no-op for a target with no light or group", async () => {
+    const repo = mockRepo();
+    const restore = installMockRepo(repo);
+    try {
+      const services = new ActionServices();
+
+      await services.ensurePreparedForTarget("ctx-1", {
+        type: "light",
+        // light is undefined — target resolution failed
+      });
+
+      expect(repo.toggleGradient).not.toHaveBeenCalled();
+    } finally {
+      restore();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Follow-up to #170 / #172. The overlay-clearing logic (`ensurePreparedForSolidColor`) only ran for `target.type === "light"`, completely skipping groups. A group of lights in gradient or nightlight mode stayed tinted when receiving solid-color commands from the plugin.

## Change

Adds `ActionServices.ensurePreparedForTarget(contextId, target)` — a target-level wrapper that:
- For single lights: delegates to the existing `ensurePreparedForSolidColor`
- For groups: iterates `group.getControllableLights()` and prepares each member

All 7 call sites (3 keypad + 4 dial actions) now use `ensurePreparedForTarget` instead of the duplicated `if (target.type === "light")` check, making the code DRY and ensuring groups get the same overlay clearing as individual lights.

## Affected actions

| Action | Type |
|---|---|
| BrightnessAction | Keypad |
| ColorAction | Keypad |
| ColorTemperatureAction | Keypad |
| BrightnessDialAction | Dial |
| ColorHueDialAction | Dial |
| ColorTempDialAction | Dial |
| SaturationDialAction | Dial |

## Test plan

- [x] `npm run type-check`
- [x] `npm run lint`
- [x] `npm run build`
- [x] `npm run test` — 308 → 311 (+3 new tests)

New tests:
1. Single-light target → delegates to per-light prepare
2. Group target with mixed capabilities → prepares each member, respects per-light caps
3. No-op for failed target resolution (no light or group)