### PR TITLE
fix: support groups in Scene and Snapshot actions

### DIFF
--- a/src/backend/actions/SceneAction.ts
+++ b/src/backend/actions/SceneAction.ts
@@ -54,7 +54,7 @@ export class SceneAction extends SingletonAction<SceneSettings> {
 
     await this.services.ensureServices(apiKey);
     const target = await this.services.resolveTarget(settings);
-    if (!target || target.type !== "light" || !target.light) {
+    if (!target) {
       await ev.action.showAlert();
       return;
     }
@@ -74,7 +74,20 @@ export class SceneAction extends SingletonAction<SceneSettings> {
       const scene = new LightScene(parsed.id, parsed.paramId, parsed.name);
       const stopSpinner = this.services.showSpinner(ev.action);
       try {
-        await this.services.applyDynamicScene(target.light, scene);
+        if (target.type === "light" && target.light) {
+          await this.services.applyDynamicScene(target.light, scene);
+        } else if (target.type === "group" && target.group) {
+          for (const light of target.group.getControllableLights()) {
+            try {
+              await this.services.applyDynamicScene(light, scene);
+            } catch (error) {
+              streamDeck.logger.warn(
+                `Scene apply failed for group member ${light.name}:`,
+                error,
+              );
+            }
+          }
+        }
       } finally {
         stopSpinner();
       }
@@ -136,12 +149,23 @@ export class SceneAction extends SingletonAction<SceneSettings> {
         selectedDeviceId: deviceId,
       });
 
-      if (!target || target.type !== "light" || !target.light) {
+      // For groups, fetch scenes from the first controllable member.
+      // Lights within a group typically share the same model and
+      // therefore expose the same scene catalogue.
+      let queryLight;
+      if (target?.type === "light" && target.light) {
+        queryLight = target.light;
+      } else if (target?.type === "group" && target.group) {
+        const members = target.group.getControllableLights();
+        queryLight = members[0];
+      }
+
+      if (!queryLight) {
         await sendToPI(actionId, { event: "getScenes", items: [] });
         return;
       }
 
-      const scenes = await this.services.getDynamicScenes(target.light);
+      const scenes = await this.services.getDynamicScenes(queryLight);
       await sendToPI(actionId, {
         event: "getScenes",
         items: scenes.map((s) => ({

--- a/src/backend/actions/SnapshotAction.ts
+++ b/src/backend/actions/SnapshotAction.ts
@@ -152,12 +152,21 @@ export class SnapshotAction extends SingletonAction<SnapshotSettings> {
         selectedDeviceId: deviceId,
       });
 
-      if (!target || target.type !== "light" || !target.light) {
+      // For groups, fetch snapshots from the first controllable member.
+      let queryLight;
+      if (target?.type === "light" && target.light) {
+        queryLight = target.light;
+      } else if (target?.type === "group" && target.group) {
+        const members = target.group.getControllableLights();
+        queryLight = members[0];
+      }
+
+      if (!queryLight) {
         await sendToPI(actionId, { event: "getSnapshots", items: [] });
         return;
       }
 
-      const snapshots = await this.services.getSnapshots(target.light);
+      const snapshots = await this.services.getSnapshots(queryLight);
       await sendToPI(actionId, {
         event: "getSnapshots",
         items: snapshots.map((s) => ({


### PR DESCRIPTION
## Summary

Scene and Snapshot actions treated groups as invalid targets — the PI dropdown returned empty and onKeyDown showed an alert. Groups are a first-class feature of this plugin; if they appear in the device dropdown, the action should work.

## Fix

**PI dropdown** (both Scene and Snapshot): for group targets, fetch scenes/snapshots from the first controllable member. Lights within a group typically share the same model and expose the same catalogue.

**SceneAction.onKeyDown**: iterate `group.getControllableLights()` and apply the scene to each member (fire-and-forget per light — one failure doesn't block the rest). Matches the pattern already used by SnapshotAction.

**SnapshotAction.handleGetSnapshots**: same first-member query. (SnapshotAction.onKeyDown already handled groups.)

## Test plan

- [x] `npm run type-check`
- [x] `npm run lint`  
- [x] `npm run build`
- [x] `npm run test` — 311 passing