### PR TITLE
fix: support groups in Music Mode and Feature Toggle actions

### DIFF
--- a/src/backend/actions/MusicModeAction.ts
+++ b/src/backend/actions/MusicModeAction.ts
@@ -52,7 +52,7 @@ export class MusicModeAction extends SingletonAction<MusicModeSettings> {
 
     await this.services.ensureServices(apiKey);
     const target = await this.services.resolveTarget(settings);
-    if (!target || target.type !== "light" || !target.light) {
+    if (!target) {
       await ev.action.showAlert();
       return;
     }
@@ -74,7 +74,20 @@ export class MusicModeAction extends SingletonAction<MusicModeSettings> {
       );
       const stopSpinner = this.services.showSpinner(ev.action);
       try {
-        await this.services.applyMusicModeRaw(target.light, musicMode);
+        if (target.type === "light" && target.light) {
+          await this.services.applyMusicModeRaw(target.light, musicMode);
+        } else if (target.type === "group" && target.group) {
+          for (const light of target.group.getControllableLights()) {
+            try {
+              await this.services.applyMusicModeRaw(light, musicMode);
+            } catch (error) {
+              streamDeck.logger.warn(
+                `Music mode apply failed for group member ${light.name}:`,
+                error,
+              );
+            }
+          }
+        }
       } finally {
         stopSpinner();
       }
@@ -133,8 +146,19 @@ export class MusicModeAction extends SingletonAction<MusicModeSettings> {
 
       await this.services.ensureServices(apiKey);
 
-      // Query device capabilities for music modes
-      const modes = await this.services.getMusicModes(deviceId);
+      // For groups, query music modes from the first controllable member.
+      const target = await this.services.resolveTarget({
+        selectedDeviceId: deviceId,
+      });
+      let queryDeviceId = deviceId;
+      if (target?.type === "group" && target.group) {
+        const first = target.group.getControllableLights()[0];
+        if (first) {
+          queryDeviceId = `light:${first.deviceId}|${first.model}`;
+        }
+      }
+
+      const modes = await this.services.getMusicModes(queryDeviceId);
       await sendToPI(actionId, {
         event: "getMusicModes",
         items: modes.map((m) => ({

--- a/src/backend/actions/ToggleAction.ts
+++ b/src/backend/actions/ToggleAction.ts
@@ -83,7 +83,7 @@ export class ToggleAction extends SingletonAction<ToggleSettings> {
 
     await this.services.ensureServices(apiKey);
     const target = await this.services.resolveTarget(settings);
-    if (!target || target.type !== "light" || !target.light) {
+    if (!target) {
       await ev.action.showAlert();
       return;
     }
@@ -105,17 +105,24 @@ export class ToggleAction extends SingletonAction<ToggleSettings> {
 
       let enabled: boolean;
       if (operation === "toggle") {
+        // For toggle mode, read live state from the first available light.
         let liveState: boolean | undefined;
-        try {
-          liveState = await this.services.getToggleFeatureState(
-            target.light,
-            parsed.instance,
-          );
-        } catch (error) {
-          streamDeck.logger.warn(
-            `Falling back to cached toggle state for ${parsed.instance}:`,
-            error,
-          );
+        const queryLight =
+          target.type === "light"
+            ? target.light
+            : target.group?.getControllableLights()[0];
+        if (queryLight) {
+          try {
+            liveState = await this.services.getToggleFeatureState(
+              queryLight,
+              parsed.instance,
+            );
+          } catch (error) {
+            streamDeck.logger.warn(
+              `Falling back to cached toggle state for ${parsed.instance}:`,
+              error,
+            );
+          }
         }
         const currentState = liveState ?? originalState;
         enabled = !currentState;
@@ -128,11 +135,28 @@ export class ToggleAction extends SingletonAction<ToggleSettings> {
 
       const stopSpinner = this.services.showSpinner(ev.action);
       try {
-        await this.services.toggleFeatureRaw(
-          target.light,
-          parsed.instance,
-          enabled,
-        );
+        if (target.type === "light" && target.light) {
+          await this.services.toggleFeatureRaw(
+            target.light,
+            parsed.instance,
+            enabled,
+          );
+        } else if (target.type === "group" && target.group) {
+          for (const light of target.group.getControllableLights()) {
+            try {
+              await this.services.toggleFeatureRaw(
+                light,
+                parsed.instance,
+                enabled,
+              );
+            } catch (error) {
+              streamDeck.logger.warn(
+                `Toggle ${parsed.instance} failed for group member ${light.name}:`,
+                error,
+              );
+            }
+          }
+        }
       } finally {
         stopSpinner();
       }
@@ -199,7 +223,20 @@ export class ToggleAction extends SingletonAction<ToggleSettings> {
       }
 
       await this.services.ensureServices(apiKey);
-      const features = await this.services.getToggleFeatures(deviceId);
+
+      // For groups, query toggle features from the first controllable member.
+      const target = await this.services.resolveTarget({
+        selectedDeviceId: deviceId,
+      });
+      let queryDeviceId = deviceId;
+      if (target?.type === "group" && target.group) {
+        const first = target.group.getControllableLights()[0];
+        if (first) {
+          queryDeviceId = `light:${first.deviceId}|${first.model}`;
+        }
+      }
+
+      const features = await this.services.getToggleFeatures(queryDeviceId);
       await sendToPI(actionId, {
         event: "getToggleFeatures",
         items: features.map((f) => ({


### PR DESCRIPTION
## Summary

Completes group support across all keypad actions. Music Mode and Feature Toggle both rejected groups in onKeyDown (alert on press) and returned empty PI dropdowns for group targets, despite groups being selectable in the device dropdown.

## Changes

### MusicModeAction
- **onKeyDown**: iterate `group.getControllableLights()`, apply music mode to each (fire-and-forget per light)
- **handleGetMusicModes**: resolve group → query modes from first controllable member

### ToggleAction
- **onKeyDown**: iterate group members, toggle each (fire-and-forget). For toggle mode, read live state from the first member.
- **handleGetToggleFeatures**: resolve group → query features from first controllable member

## Full group audit — now complete

| Action | PI dropdown | onKeyDown | Status |
|---|---|---|---|
| On/Off | ✅ | ✅ `controlGroup` | Already worked |
| Brightness | ✅ | ✅ `controlGroup` | Already worked |
| Color | ✅ | ✅ `controlGroup` | Already worked |
| Color Temperature | ✅ | ✅ `controlGroup` | Already worked |
| Segment Color | N/A | Single-light only (by design) | OK |
| Scene | ✅ | ✅ Fixed in #179 | Done |
| Snapshot | ✅ | ✅ Fixed in #179 | Done |
| Music Mode | ✅ | ✅ **This PR** | Done |
| Feature Toggle | ✅ | ✅ **This PR** | Done |
| Overlay clearing | N/A | ✅ Fixed in #178 | Done |

## Test plan

- [x] `npm run type-check`
- [x] `npm run lint`
- [x] `npm run build`
- [x] `npm run test` — 311 passing