### PR TITLE
fix: surface proper empty/error states in PI dropdowns (#182)

### DIFF
--- a/com.felixgeelhaar.govee-light-management.sdPlugin/ui/css/main.css
+++ b/com.felixgeelhaar.govee-light-management.sdPlugin/ui/css/main.css
@@ -219,3 +219,17 @@
 	background-color: #3a3a3a;
 	color: #ffffff;
 }
+
+.field-hint {
+	font-size: 11px;
+	padding: 4px 0 0;
+	line-height: 1.4;
+}
+
+.field-hint.info {
+	color: #9da3ae;
+}
+
+.field-hint.error {
+	color: #ff6b6b;
+}

--- a/com.felixgeelhaar.govee-light-management.sdPlugin/ui/js/setup.js
+++ b/com.felixgeelhaar.govee-light-management.sdPlugin/ui/js/setup.js
@@ -632,9 +632,11 @@ document.addEventListener("DOMContentLoaded", () => {
     sendPluginMessage(client, { event: "getDevices" });
   }
 
-  // ── Device Dropdown Timeout ──
-  // If the dropdown stays on "Loading" for too long (backend crashed or
-  // API unreachable), show a helpful hint so the user isn't stuck.
+  // ── Device Dropdown Status ──
+  // Wires the Device dropdown to the shared attachFieldStatus helper so
+  // explicit backend errors ("Missing API key", "Failed to load devices") are
+  // surfaced, plus a 15s fallback hint if the backend never responds at all
+  // (e.g. plugin crashed).
   function watchDeviceDropdown(client) {
     const TIMEOUT_MS = 15_000;
     const deviceSelect = document.querySelector(
@@ -657,25 +659,29 @@ document.addEventListener("DOMContentLoaded", () => {
     deviceSelect.addEventListener("change", rerenderDebug);
     deviceSelect.addEventListener("input", rerenderDebug);
 
+    attachFieldStatus(client, deviceSelect, "getDevices", {
+      emptyMsg:
+        "No devices found. Add lights in the Govee mobile app, then refresh.",
+      errorMsg:
+        "Failed to load devices. Check your API key and connection, then refresh.",
+    });
+
+    // Fallback: if no getDevices response arrives at all (plugin crashed,
+    // message lost), show a hint after the timeout window.
     const timer = setTimeout(() => {
-      // Check if the dropdown is still empty / loading
       const hasOptions =
         deviceSelect.querySelectorAll("option").length > 0 ||
         deviceSelect.value;
       if (hasOptions) return;
-
-      // Insert a hint below the dropdown
       if (document.getElementById("deviceTimeout")) return;
       const hint = document.createElement("div");
       hint.id = "deviceTimeout";
-      hint.style.cssText =
-        "color:#FF6B6B;font-size:12px;padding:6px 0;line-height:1.4";
+      hint.className = "field-hint error";
       hint.textContent =
         "Devices didn't load. Check your API key, try the refresh button, or restart the Stream Deck app.";
       deviceSelect.parentNode.insertBefore(hint, deviceSelect.nextSibling);
     }, TIMEOUT_MS);
 
-    // Clear timeout if devices arrive
     const unsubscribeMessages = subscribePluginMessages(client, (p) => {
       if (!p || typeof p !== "object") return;
       if (p.event === "getDevices") {
@@ -688,6 +694,126 @@ document.addEventListener("DOMContentLoaded", () => {
       }
     });
   }
+
+  // ── Field Status Hints ──
+  // Attaches an inline hint element below a dependent dropdown and updates it
+  // based on backend responses. Used to distinguish "empty because no device
+  // selected" (default placeholder) from "empty because device has no items"
+  // or "empty because the backend errored". Shared across all PIs.
+  function attachFieldStatus(client, selectEl, event, opts) {
+    if (!selectEl || !event) return () => {};
+    const { emptyMsg, errorMsg, timeoutMs = 15_000 } = opts || {};
+    const parent = selectEl.parentNode;
+    if (!parent) return () => {};
+
+    const hint = document.createElement("div");
+    hint.className = "field-hint info hidden";
+    hint.setAttribute("data-field-hint", event);
+    parent.insertBefore(hint, selectEl.nextSibling);
+
+    let timer = null;
+
+    function show(text, kind) {
+      hint.textContent = text;
+      hint.className = `field-hint ${kind}`;
+    }
+    function hide() {
+      hint.textContent = "";
+      hint.className = "field-hint info hidden";
+    }
+
+    function armTimeout() {
+      if (timer) clearTimeout(timer);
+      timer = setTimeout(() => {
+        // Only show the timeout hint if the dropdown is still empty
+        const hasOptions =
+          selectEl.querySelectorAll("option").length > 0 || selectEl.value;
+        if (!hasOptions && errorMsg) {
+          show(
+            "Request timed out. Check your connection, API key, or Stream Deck plugin state.",
+            "error",
+          );
+        }
+      }, timeoutMs);
+    }
+
+    const unsubscribe = subscribePluginMessages(client, (p) => {
+      if (!p || typeof p !== "object" || p.event !== event) return;
+      if (timer) {
+        clearTimeout(timer);
+        timer = null;
+      }
+      const status = p.status;
+      const message = typeof p.message === "string" ? p.message : null;
+      const items = Array.isArray(p.items) ? p.items : [];
+
+      if (status === "error") {
+        show(message || errorMsg || "Failed to load options.", "error");
+        return;
+      }
+      if (status === "empty") {
+        show(message || emptyMsg || "No options available.", "info");
+        return;
+      }
+      if (items.length === 0 && status === "ok") {
+        // Backend explicitly said ok but list is empty (rare; treat as empty)
+        show(message || emptyMsg || "No options available.", "info");
+        return;
+      }
+      if (items.length > 0) {
+        hide();
+        return;
+      }
+      // No status field (legacy): keep hint hidden — placeholder does its job.
+    });
+
+    return {
+      armTimeout,
+      hide,
+      dispose: () => {
+        if (timer) clearTimeout(timer);
+        unsubscribe();
+        if (hint.parentNode) hint.parentNode.removeChild(hint);
+      },
+    };
+  }
+
+  // ── Ready Queue ──
+  // Per-PI scripts can call GoveePI.ready(fn) to receive the SDPI client
+  // once it's initialized. Handles both "registered before ready" and
+  // "registered after ready" cases.
+  const readyQueue = [];
+  let readyClient = null;
+  function fireReady(client) {
+    readyClient = client;
+    while (readyQueue.length) {
+      const fn = readyQueue.shift();
+      try {
+        fn(client);
+      } catch (error) {
+        console.warn("GoveePI.ready callback failed", error);
+      }
+    }
+  }
+
+  window.GoveePI = window.GoveePI || {};
+  window.GoveePI.ready = function (fn) {
+    if (typeof fn !== "function") return;
+    if (readyClient) fn(readyClient);
+    else readyQueue.push(fn);
+  };
+  window.GoveePI.attachFieldStatus = function (selectEl, event, opts) {
+    if (!readyClient) {
+      // Defer until ready
+      let handle = null;
+      const pending = { dispose: () => handle && handle.dispose() };
+      window.GoveePI.ready((client) => {
+        handle = attachFieldStatus(client, selectEl, event, opts);
+      });
+      return pending;
+    }
+    return attachFieldStatus(readyClient, selectEl, event, opts);
+  };
 
   // ── Initialize ──
   function init() {
@@ -732,6 +858,7 @@ document.addEventListener("DOMContentLoaded", () => {
     } catch (error) {
       console.warn("Failed to initialize group manager", error);
     }
+    fireReady(client);
   }
 
   const check = setInterval(() => {

--- a/com.felixgeelhaar.govee-light-management.sdPlugin/ui/music-mode.html
+++ b/com.felixgeelhaar.govee-light-management.sdPlugin/ui/music-mode.html
@@ -76,6 +76,12 @@
         const deviceSelect = document.getElementById("deviceSelect");
         const modeSelect = document.getElementById("modeSelect");
 
+        window.GoveePI.attachFieldStatus(modeSelect, "getMusicModes", {
+          emptyMsg: "This device doesn't support music modes.",
+          errorMsg:
+            "Couldn't load music modes. Check your connection and try again.",
+        });
+
         // When device changes, refresh the music modes list
         deviceSelect.addEventListener("valuechange", () => {
           if (modeSelect && modeSelect.refresh) {

--- a/com.felixgeelhaar.govee-light-management.sdPlugin/ui/scene.html
+++ b/com.felixgeelhaar.govee-light-management.sdPlugin/ui/scene.html
@@ -92,6 +92,12 @@
           }
         };
 
+        window.GoveePI.attachFieldStatus(sceneSelect, "getScenes", {
+          emptyMsg: "This device has no dynamic scenes available.",
+          errorMsg:
+            "Couldn't load scenes. Check your connection and try again.",
+        });
+
         // When device changes, refresh the scene list
         deviceSelect.addEventListener("valuechange", refreshScenes);
         deviceSelect.addEventListener("change", refreshScenes);

--- a/com.felixgeelhaar.govee-light-management.sdPlugin/ui/snapshot.html
+++ b/com.felixgeelhaar.govee-light-management.sdPlugin/ui/snapshot.html
@@ -60,6 +60,13 @@
         const deviceSelect = document.getElementById("deviceSelect");
         const snapshotSelect = document.getElementById("snapshotSelect");
 
+        window.GoveePI.attachFieldStatus(snapshotSelect, "getSnapshots", {
+          emptyMsg:
+            "No snapshots found. Create one in the Govee mobile app first.",
+          errorMsg:
+            "Couldn't load snapshots. Check your connection and try again.",
+        });
+
         // When device changes, refresh the snapshot list
         deviceSelect.addEventListener("valuechange", () => {
           if (snapshotSelect && snapshotSelect.refresh) {

--- a/com.felixgeelhaar.govee-light-management.sdPlugin/ui/toggle.html
+++ b/com.felixgeelhaar.govee-light-management.sdPlugin/ui/toggle.html
@@ -68,6 +68,12 @@
         const deviceSelect = document.getElementById("deviceSelect");
         const featureSelect = document.getElementById("featureSelect");
 
+        window.GoveePI.attachFieldStatus(featureSelect, "getToggleFeatures", {
+          emptyMsg: "This device has no toggleable features.",
+          errorMsg:
+            "Couldn't load toggleable features. Check your connection and try again.",
+        });
+
         // When device changes, refresh the feature list
         deviceSelect.addEventListener("valuechange", () => {
           if (featureSelect && featureSelect.refresh) {

--- a/src/backend/actions/MusicModeAction.ts
+++ b/src/backend/actions/MusicModeAction.ts
@@ -141,14 +141,24 @@ export class MusicModeAction extends SingletonAction<MusicModeSettings> {
   ): Promise<void> {
     const deviceId = settings.selectedDeviceId;
     if (!deviceId) {
-      await sendToPI(actionId, { event: "getMusicModes", items: [] });
+      await sendToPI(actionId, {
+        event: "getMusicModes",
+        items: [],
+        status: "empty",
+        message: "Select a device to load its music modes.",
+      });
       return;
     }
 
     try {
       const apiKey = await this.services.getApiKey(settings);
       if (!apiKey) {
-        await sendToPI(actionId, { event: "getMusicModes", items: [] });
+        await sendToPI(actionId, {
+          event: "getMusicModes",
+          items: [],
+          status: "error",
+          message: "Missing API key — reconnect in the API Key panel.",
+        });
         return;
       }
 
@@ -167,8 +177,18 @@ export class MusicModeAction extends SingletonAction<MusicModeSettings> {
       }
 
       const modes = await this.services.getMusicModes(queryDeviceId);
+      if (modes.length === 0) {
+        await sendToPI(actionId, {
+          event: "getMusicModes",
+          items: [],
+          status: "empty",
+          message: "This device doesn't support music modes.",
+        });
+        return;
+      }
       await sendToPI(actionId, {
         event: "getMusicModes",
+        status: "ok",
         items: modes.map((m) => ({
           label: m.name,
           value: JSON.stringify({ name: m.name, modeId: m.value }),
@@ -176,7 +196,12 @@ export class MusicModeAction extends SingletonAction<MusicModeSettings> {
       });
     } catch (error) {
       streamDeck.logger.error("Failed to fetch music modes:", error);
-      await sendToPI(actionId, { event: "getMusicModes", items: [] });
+      await sendToPI(actionId, {
+        event: "getMusicModes",
+        items: [],
+        status: "error",
+        message: "Failed to load music modes. Check your connection and retry.",
+      });
     }
   }
 

--- a/src/backend/actions/SceneAction.ts
+++ b/src/backend/actions/SceneAction.ts
@@ -169,14 +169,24 @@ export class SceneAction extends SingletonAction<SceneSettings> {
   ): Promise<void> {
     const deviceId = settings.selectedDeviceId;
     if (!deviceId) {
-      await sendToPI(actionId, { event: "getScenes", items: [] });
+      await sendToPI(actionId, {
+        event: "getScenes",
+        items: [],
+        status: "empty",
+        message: "Select a device to load its scenes.",
+      });
       return;
     }
 
     try {
       const apiKey = await this.services.getApiKey(settings ?? {});
       if (!apiKey) {
-        await sendToPI(actionId, { event: "getScenes", items: [] });
+        await sendToPI(actionId, {
+          event: "getScenes",
+          items: [],
+          status: "error",
+          message: "Missing API key — reconnect in the API Key panel.",
+        });
         return;
       }
 
@@ -197,7 +207,13 @@ export class SceneAction extends SingletonAction<SceneSettings> {
       }
 
       if (!queryLight) {
-        await sendToPI(actionId, { event: "getScenes", items: [] });
+        await sendToPI(actionId, {
+          event: "getScenes",
+          items: [],
+          status: "error",
+          message:
+            "Selected device could not be resolved. Try refreshing devices.",
+        });
         return;
       }
 
@@ -205,13 +221,30 @@ export class SceneAction extends SingletonAction<SceneSettings> {
         this.services.getDynamicScenes(queryLight),
         this.services.getDiyScenes(queryLight),
       ]);
+      const items = buildSceneItems(dynamicScenes, diyScenes);
+      if (items.length === 0) {
+        await sendToPI(actionId, {
+          event: "getScenes",
+          items: [],
+          status: "empty",
+          message:
+            "This device has no dynamic or DIY scenes available. Create scenes in the Govee mobile app first.",
+        });
+        return;
+      }
       await sendToPI(actionId, {
         event: "getScenes",
-        items: buildSceneItems(dynamicScenes, diyScenes),
+        status: "ok",
+        items,
       });
     } catch (error) {
       streamDeck.logger.error("Failed to fetch scenes:", error);
-      await sendToPI(actionId, { event: "getScenes", items: [] });
+      await sendToPI(actionId, {
+        event: "getScenes",
+        items: [],
+        status: "error",
+        message: "Failed to load scenes. Check your connection and retry.",
+      });
     }
   }
 

--- a/src/backend/actions/SnapshotAction.ts
+++ b/src/backend/actions/SnapshotAction.ts
@@ -144,14 +144,24 @@ export class SnapshotAction extends SingletonAction<SnapshotSettings> {
   ): Promise<void> {
     const deviceId = settings.selectedDeviceId;
     if (!deviceId) {
-      await sendToPI(actionId, { event: "getSnapshots", items: [] });
+      await sendToPI(actionId, {
+        event: "getSnapshots",
+        items: [],
+        status: "empty",
+        message: "Select a device to load its snapshots.",
+      });
       return;
     }
 
     try {
       const apiKey = await this.services.getApiKey(settings ?? {});
       if (!apiKey) {
-        await sendToPI(actionId, { event: "getSnapshots", items: [] });
+        await sendToPI(actionId, {
+          event: "getSnapshots",
+          items: [],
+          status: "error",
+          message: "Missing API key — reconnect in the API Key panel.",
+        });
         return;
       }
 
@@ -170,13 +180,30 @@ export class SnapshotAction extends SingletonAction<SnapshotSettings> {
       }
 
       if (!queryLight) {
-        await sendToPI(actionId, { event: "getSnapshots", items: [] });
+        await sendToPI(actionId, {
+          event: "getSnapshots",
+          items: [],
+          status: "error",
+          message:
+            "Selected device could not be resolved. Try refreshing devices.",
+        });
         return;
       }
 
       const snapshots = await this.services.getSnapshots(queryLight);
+      if (snapshots.length === 0) {
+        await sendToPI(actionId, {
+          event: "getSnapshots",
+          items: [],
+          status: "empty",
+          message:
+            "No snapshots found. Create one in the Govee mobile app first.",
+        });
+        return;
+      }
       await sendToPI(actionId, {
         event: "getSnapshots",
+        status: "ok",
         items: snapshots.map((s) => ({
           label: s.name,
           value: JSON.stringify({
@@ -188,7 +215,12 @@ export class SnapshotAction extends SingletonAction<SnapshotSettings> {
       });
     } catch (error) {
       streamDeck.logger.error("Failed to fetch snapshots:", error);
-      await sendToPI(actionId, { event: "getSnapshots", items: [] });
+      await sendToPI(actionId, {
+        event: "getSnapshots",
+        items: [],
+        status: "error",
+        message: "Failed to load snapshots. Check your connection and retry.",
+      });
     }
   }
 

--- a/src/backend/actions/ToggleAction.ts
+++ b/src/backend/actions/ToggleAction.ts
@@ -219,14 +219,24 @@ export class ToggleAction extends SingletonAction<ToggleSettings> {
   ): Promise<void> {
     const deviceId = settings.selectedDeviceId;
     if (!deviceId) {
-      await sendToPI(actionId, { event: "getToggleFeatures", items: [] });
+      await sendToPI(actionId, {
+        event: "getToggleFeatures",
+        items: [],
+        status: "empty",
+        message: "Select a device to load its toggleable features.",
+      });
       return;
     }
 
     try {
       const apiKey = await this.services.getApiKey(settings);
       if (!apiKey) {
-        await sendToPI(actionId, { event: "getToggleFeatures", items: [] });
+        await sendToPI(actionId, {
+          event: "getToggleFeatures",
+          items: [],
+          status: "error",
+          message: "Missing API key — reconnect in the API Key panel.",
+        });
         return;
       }
 
@@ -245,8 +255,18 @@ export class ToggleAction extends SingletonAction<ToggleSettings> {
       }
 
       const features = await this.services.getToggleFeatures(queryDeviceId);
+      if (features.length === 0) {
+        await sendToPI(actionId, {
+          event: "getToggleFeatures",
+          items: [],
+          status: "empty",
+          message: "This device has no toggleable features.",
+        });
+        return;
+      }
       await sendToPI(actionId, {
         event: "getToggleFeatures",
+        status: "ok",
         items: features.map((f) => ({
           label: f.name,
           value: JSON.stringify({ name: f.name, instance: f.instance }),
@@ -254,7 +274,13 @@ export class ToggleAction extends SingletonAction<ToggleSettings> {
       });
     } catch (error) {
       streamDeck.logger.error("Failed to fetch toggle features:", error);
-      await sendToPI(actionId, { event: "getToggleFeatures", items: [] });
+      await sendToPI(actionId, {
+        event: "getToggleFeatures",
+        items: [],
+        status: "error",
+        message:
+          "Failed to load toggleable features. Check your connection and retry.",
+      });
     }
   }
 

--- a/src/backend/actions/shared/ActionServices.ts
+++ b/src/backend/actions/shared/ActionServices.ts
@@ -486,6 +486,8 @@ export class ActionServices {
         await sendToPI(actionId, {
           event: "getDevices",
           items: [],
+          status: "error",
+          message: "Missing API key — reconnect in the API Key panel.",
         });
         return;
       }
@@ -496,6 +498,8 @@ export class ActionServices {
         value: string;
         children?: Array<{ label: string; value: string }>;
       }> = [];
+
+      let discoveryFailed = false;
 
       // Add lights (with timeout to prevent hanging)
       if (this.deviceService) {
@@ -527,6 +531,7 @@ export class ActionServices {
             "handleGetDevices: device discovery failed:",
             discoverError,
           );
+          discoveryFailed = true;
           // Continue to still return groups even if light discovery fails
         }
       }
@@ -551,15 +556,29 @@ export class ActionServices {
       streamDeck.logger.info(
         `handleGetDevices: sending ${items.length} item groups to PI`,
       );
+      if (items.length === 0) {
+        await sendToPI(actionId, {
+          event: "getDevices",
+          items: [],
+          status: discoveryFailed ? "error" : "empty",
+          message: discoveryFailed
+            ? "Failed to load devices. Check your API key and connection."
+            : "No devices found. Add lights in the Govee mobile app, then refresh.",
+        });
+        return;
+      }
       await sendToPI(actionId, {
         event: "getDevices",
         items,
+        status: "ok",
       });
     } catch (error) {
       streamDeck.logger.error("Failed to fetch devices:", error);
       await sendToPI(actionId, {
         event: "getDevices",
         items: [],
+        status: "error",
+        message: "Failed to load devices. Check your API key and connection.",
       });
     }
   }


### PR DESCRIPTION
Closes #182.

## Summary
- Every Property Inspector dependent-dropdown response (`getSnapshots`, `getScenes`, `getMusicModes`, `getToggleFeatures`, `getDevices`) now carries an explicit `status` (`ok` | `empty` | `error`) and a context-specific `message` instead of collapsing empty-result and error into an ambiguous `items: []`.
- New shared frontend helper `GoveePI.attachFieldStatus(selectEl, event, { emptyMsg, errorMsg })` inserts an inline hint under a dropdown and drives it from backend status, so users see *why* a list is empty.
- `setup.js:watchDeviceDropdown` uses the shared helper on the Device dropdown while preserving the existing 15s fallback-timeout path for the plugin-crashed case.
- Dependent-dropdown PIs (snapshot, scene, music-mode, toggle) wire the helper with context-appropriate copy — e.g. snapshot shows *"No snapshots found. Create one in the Govee mobile app first."* instead of the misleading *"Select a device first"* placeholder.
- Scene merges dynamic + DIY scene emptiness into one friendly hint now that #181 is merged.

## Test plan
- [x] `npm run type-check`
- [x] `npm run lint`
- [x] `npm run test` (491 passing)
- [x] `npm run build`
- [ ] Manual: open Snapshot PI with a device that has no saved snapshots → see "No snapshots found..." hint
- [ ] Manual: open Scene PI on an unsupported device → see "This device has no dynamic or DIY scenes..." hint
- [ ] Manual: toggle off network / revoke API key → see "Failed to load devices..." hint