### PR TITLE
Bug music/snapshot

### DIFF
--- a/com.felixgeelhaar.govee-light-management.sdPlugin/ui/music-mode.html
+++ b/com.felixgeelhaar.govee-light-management.sdPlugin/ui/music-mode.html
@@ -25,8 +25,6 @@
         <sdpi-select
           id="modeSelect"
           setting="selectedMode"
-          datasource="getMusicModes"
-          show-refresh
           placeholder="Select a device first"
         ></sdpi-select>
       </sdpi-item>
@@ -72,17 +70,171 @@
     </div>
 
     <script>
-      document.addEventListener("DOMContentLoaded", () => {
+      function setupDependentRefresh() {
+        if (window.__goveeMusicModeDependentRefreshSetup) {
+          return;
+        }
+        window.__goveeMusicModeDependentRefreshSetup = true;
+
         const deviceSelect = document.getElementById("deviceSelect");
         const modeSelect = document.getElementById("modeSelect");
+        const client = window.SDPIComponents?.streamDeckClient;
+        let currentSettings = {};
+        let requestTimer = null;
+        let lastRequestedDeviceId = "";
+        let lastPopulatedDeviceId = "";
 
-        // When device changes, refresh the music modes list
-        deviceSelect.addEventListener("valuechange", () => {
-          if (modeSelect && modeSelect.refresh) {
-            modeSelect.refresh();
+        function toPayload(message) {
+          if (
+            message &&
+            typeof message === "object" &&
+            "payload" in message &&
+            message.payload
+          ) {
+            return message.payload;
+          }
+          return message || {};
+        }
+
+        function sendPluginMessage(payload) {
+          if (client && typeof client.sendToPlugin === "function") {
+            client.sendToPlugin(payload);
+            return;
+          }
+          if (client && typeof client.send === "function") {
+            client.send("sendToPlugin", payload);
+          }
+        }
+
+        function subscribePluginMessages(onMessage) {
+          const sources = [
+            client && client.sendToPropertyInspector,
+            client && client.message,
+          ].filter(Boolean);
+
+          sources.forEach((source) => {
+            if (source && typeof source.subscribe === "function") {
+              source.subscribe((message) => onMessage(toPayload(message)));
+            }
+          });
+        }
+
+        function getSelectedDeviceId() {
+          return (
+            currentSettings.selectedDeviceId ||
+            deviceSelect?.shadowRoot?.querySelector("select")?.value ||
+            deviceSelect?.value ||
+            deviceSelect?.getAttribute?.("value") ||
+            deviceSelect?.getAttribute?.("default-value") ||
+            ""
+          );
+        }
+
+        function setPlaceholder(text) {
+          while (modeSelect.children.length > 0) {
+            modeSelect.removeChild(modeSelect.lastChild);
+          }
+          const placeholder = document.createElement("option");
+          placeholder.value = "";
+          placeholder.textContent = text;
+          placeholder.disabled = true;
+          placeholder.selected = true;
+          modeSelect.appendChild(placeholder);
+        }
+
+        function populateModes(items) {
+          lastPopulatedDeviceId = getSelectedDeviceId();
+          if (!items || items.length === 0) {
+            setPlaceholder("No music modes found for this device");
+            return;
+          }
+
+          while (modeSelect.children.length > 0) {
+            modeSelect.removeChild(modeSelect.lastChild);
+          }
+
+          items.forEach((item) => {
+            const option = document.createElement("option");
+            option.value = item.value;
+            option.textContent = item.label;
+            modeSelect.appendChild(option);
+          });
+        }
+
+        function requestModes() {
+          const selectedDeviceId = getSelectedDeviceId();
+          if (!selectedDeviceId) {
+            lastRequestedDeviceId = "";
+            setPlaceholder("Select a device first");
+            return;
+          }
+
+          if (
+            selectedDeviceId === lastRequestedDeviceId &&
+            selectedDeviceId === lastPopulatedDeviceId
+          ) {
+            return;
+          }
+
+          lastRequestedDeviceId = selectedDeviceId;
+
+          sendPluginMessage({
+            event: "getMusicModes",
+            selectedDeviceId,
+          });
+        }
+
+        if (client?.didReceiveSettings?.subscribe) {
+          client.didReceiveSettings.subscribe((msg) => {
+            currentSettings = msg?.payload?.settings || {};
+            if (!currentSettings.selectedDeviceId) {
+              lastRequestedDeviceId = "";
+              lastPopulatedDeviceId = "";
+            }
+            scheduleRequest();
+          });
+        }
+
+        subscribePluginMessages((payload) => {
+          if (payload?.event === "getMusicModes") {
+            populateModes(payload.items || []);
           }
         });
-      });
+
+        function scheduleRequest() {
+          if (requestTimer) {
+            clearTimeout(requestTimer);
+          }
+          requestTimer = setTimeout(() => {
+            requestTimer = null;
+            requestModes();
+          }, 120);
+        }
+
+        ["valuechange", "change", "input"].forEach((eventName) => {
+          deviceSelect.addEventListener(eventName, () => {
+            const selectedDeviceId = getSelectedDeviceId();
+            if (selectedDeviceId !== lastRequestedDeviceId) {
+              lastPopulatedDeviceId = "";
+            }
+            if (client?.setSettings && selectedDeviceId) {
+              currentSettings = {
+                ...currentSettings,
+                selectedDeviceId,
+              };
+              client.setSettings({
+                ...currentSettings,
+              });
+            }
+            scheduleRequest();
+          });
+        });
+
+        scheduleRequest();
+      }
+
+      document.addEventListener("DOMContentLoaded", setupDependentRefresh);
+      if (document.readyState !== "loading") setupDependentRefresh();
     </script>
   </body>
 </html>

--- a/com.felixgeelhaar.govee-light-management.sdPlugin/ui/scene.html
+++ b/com.felixgeelhaar.govee-light-management.sdPlugin/ui/scene.html
@@ -56,17 +56,56 @@
     </div>
 
     <script>
-      document.addEventListener("DOMContentLoaded", () => {
+      function setupDependentRefresh() {
         const deviceSelect = document.getElementById("deviceSelect");
         const sceneSelect = document.getElementById("sceneSelect");
+        const client = window.SDPIComponents?.streamDeckClient;
+        let currentSettings = {};
 
-        // When device changes, refresh the scene list
-        deviceSelect.addEventListener("valuechange", () => {
+        const refreshScenes = () => {
           if (sceneSelect && sceneSelect.refresh) {
             sceneSelect.refresh();
           }
+        };
+
+        const getSelectedDeviceLabel = () => {
+          const nativeSelect = deviceSelect?.shadowRoot?.querySelector("select");
+          return nativeSelect?.selectedOptions?.[0]?.innerText?.trim() || "";
+        };
+
+        const scheduleRefresh = () => {
+          setTimeout(refreshScenes, 0);
+          setTimeout(refreshScenes, 100);
+        };
+
+        if (client?.didReceiveSettings?.subscribe) {
+          client.didReceiveSettings.subscribe((msg) => {
+            currentSettings = msg?.payload?.settings || {};
+            scheduleRefresh();
+          });
+        }
+
+        const persistSelectionAndRefresh = () => {
+          const selectedDeviceId = deviceSelect?.value || "";
+          if (client?.setSettings && selectedDeviceId) {
+            client.setSettings({
+              ...currentSettings,
+              selectedDeviceId,
+              selectedLightName: getSelectedDeviceLabel(),
+            });
+          }
+          scheduleRefresh();
+        };
+
+        ["valuechange", "change", "input"].forEach((eventName) => {
+          deviceSelect.addEventListener(eventName, persistSelectionAndRefresh);
         });
-      });
+
+        scheduleRefresh();
+      }
+
+      document.addEventListener("DOMContentLoaded", setupDependentRefresh);
+      if (document.readyState !== "loading") setupDependentRefresh();
     </script>
   </body>
 </html>

--- a/com.felixgeelhaar.govee-light-management.sdPlugin/ui/snapshot.html
+++ b/com.felixgeelhaar.govee-light-management.sdPlugin/ui/snapshot.html
@@ -24,8 +24,6 @@
         <sdpi-select
           id="snapshotSelect"
           setting="selectedSnapshot"
-          datasource="getSnapshots"
-          show-refresh
           placeholder="Select a device first"
         ></sdpi-select>
       </sdpi-item>
@@ -56,17 +54,171 @@
     </div>
 
     <script>
-      document.addEventListener("DOMContentLoaded", () => {
+      function setupDependentRefresh() {
+        if (window.__goveeSnapshotDependentRefreshSetup) {
+          return;
+        }
+        window.__goveeSnapshotDependentRefreshSetup = true;
+
         const deviceSelect = document.getElementById("deviceSelect");
         const snapshotSelect = document.getElementById("snapshotSelect");
+        const client = window.SDPIComponents?.streamDeckClient;
+        let currentSettings = {};
+        let requestTimer = null;
+        let lastRequestedDeviceId = "";
+        let lastPopulatedDeviceId = "";
 
-        // When device changes, refresh the snapshot list
-        deviceSelect.addEventListener("valuechange", () => {
-          if (snapshotSelect && snapshotSelect.refresh) {
-            snapshotSelect.refresh();
+        function toPayload(message) {
+          if (
+            message &&
+            typeof message === "object" &&
+            "payload" in message &&
+            message.payload
+          ) {
+            return message.payload;
+          }
+          return message || {};
+        }
+
+        function sendPluginMessage(payload) {
+          if (client && typeof client.sendToPlugin === "function") {
+            client.sendToPlugin(payload);
+            return;
+          }
+          if (client && typeof client.send === "function") {
+            client.send("sendToPlugin", payload);
+          }
+        }
+
+        function subscribePluginMessages(onMessage) {
+          const sources = [
+            client && client.sendToPropertyInspector,
+            client && client.message,
+          ].filter(Boolean);
+
+          sources.forEach((source) => {
+            if (source && typeof source.subscribe === "function") {
+              source.subscribe((message) => onMessage(toPayload(message)));
+            }
+          });
+        }
+
+        function getSelectedDeviceId() {
+          return (
+            currentSettings.selectedDeviceId ||
+            deviceSelect?.shadowRoot?.querySelector("select")?.value ||
+            deviceSelect?.value ||
+            deviceSelect?.getAttribute?.("value") ||
+            deviceSelect?.getAttribute?.("default-value") ||
+            ""
+          );
+        }
+
+        function setPlaceholder(text) {
+          while (snapshotSelect.children.length > 0) {
+            snapshotSelect.removeChild(snapshotSelect.lastChild);
+          }
+          const placeholder = document.createElement("option");
+          placeholder.value = "";
+          placeholder.textContent = text;
+          placeholder.disabled = true;
+          placeholder.selected = true;
+          snapshotSelect.appendChild(placeholder);
+        }
+
+        function populateSnapshots(items) {
+          lastPopulatedDeviceId = getSelectedDeviceId();
+          if (!items || items.length === 0) {
+            setPlaceholder("No snapshots found for this device");
+            return;
+          }
+
+          while (snapshotSelect.children.length > 0) {
+            snapshotSelect.removeChild(snapshotSelect.lastChild);
+          }
+
+          items.forEach((item) => {
+            const option = document.createElement("option");
+            option.value = item.value;
+            option.textContent = item.label;
+            snapshotSelect.appendChild(option);
+          });
+        }
+
+        function requestSnapshots() {
+          const selectedDeviceId = getSelectedDeviceId();
+          if (!selectedDeviceId) {
+            lastRequestedDeviceId = "";
+            setPlaceholder("Select a device first");
+            return;
+          }
+
+          if (
+            selectedDeviceId === lastRequestedDeviceId &&
+            selectedDeviceId === lastPopulatedDeviceId
+          ) {
+            return;
+          }
+
+          lastRequestedDeviceId = selectedDeviceId;
+
+          sendPluginMessage({
+            event: "getSnapshots",
+            selectedDeviceId,
+          });
+        }
+
+        if (client?.didReceiveSettings?.subscribe) {
+          client.didReceiveSettings.subscribe((msg) => {
+            currentSettings = msg?.payload?.settings || {};
+            if (!currentSettings.selectedDeviceId) {
+              lastRequestedDeviceId = "";
+              lastPopulatedDeviceId = "";
+            }
+            scheduleRequest();
+          });
+        }
+
+        subscribePluginMessages((payload) => {
+          if (payload?.event === "getSnapshots") {
+            populateSnapshots(payload.items || []);
           }
         });
-      });
+
+        function scheduleRequest() {
+          if (requestTimer) {
+            clearTimeout(requestTimer);
+          }
+          requestTimer = setTimeout(() => {
+            requestTimer = null;
+            requestSnapshots();
+          }, 120);
+        }
+
+        ["valuechange", "change", "input"].forEach((eventName) => {
+          deviceSelect.addEventListener(eventName, () => {
+            const selectedDeviceId = getSelectedDeviceId();
+            if (selectedDeviceId !== lastRequestedDeviceId) {
+              lastPopulatedDeviceId = "";
+            }
+            if (client?.setSettings && selectedDeviceId) {
+              currentSettings = {
+                ...currentSettings,
+                selectedDeviceId,
+              };
+              client.setSettings({
+                ...currentSettings,
+              });
+            }
+            scheduleRequest();
+          });
+        });
+
+        scheduleRequest();
+      }
+
+      document.addEventListener("DOMContentLoaded", setupDependentRefresh);
+      if (document.readyState !== "loading") setupDependentRefresh();
     </script>
   </body>
 </html>

--- a/com.felixgeelhaar.govee-light-management.sdPlugin/ui/toggle.html
+++ b/com.felixgeelhaar.govee-light-management.sdPlugin/ui/toggle.html
@@ -64,17 +64,56 @@
     </div>
 
     <script>
-      document.addEventListener("DOMContentLoaded", () => {
+      function setupDependentRefresh() {
         const deviceSelect = document.getElementById("deviceSelect");
         const featureSelect = document.getElementById("featureSelect");
+        const client = window.SDPIComponents?.streamDeckClient;
+        let currentSettings = {};
 
-        // When device changes, refresh the feature list
-        deviceSelect.addEventListener("valuechange", () => {
+        const refreshFeatures = () => {
           if (featureSelect && featureSelect.refresh) {
             featureSelect.refresh();
           }
+        };
+
+        const getSelectedDeviceLabel = () => {
+          const nativeSelect = deviceSelect?.shadowRoot?.querySelector("select");
+          return nativeSelect?.selectedOptions?.[0]?.innerText?.trim() || "";
+        };
+
+        const scheduleRefresh = () => {
+          setTimeout(refreshFeatures, 0);
+          setTimeout(refreshFeatures, 100);
+        };
+
+        if (client?.didReceiveSettings?.subscribe) {
+          client.didReceiveSettings.subscribe((msg) => {
+            currentSettings = msg?.payload?.settings || {};
+            scheduleRefresh();
+          });
+        }
+
+        const persistSelectionAndRefresh = () => {
+          const selectedDeviceId = deviceSelect?.value || "";
+          if (client?.setSettings && selectedDeviceId) {
+            client.setSettings({
+              ...currentSettings,
+              selectedDeviceId,
+              selectedLightName: getSelectedDeviceLabel(),
+            });
+          }
+          scheduleRefresh();
+        };
+
+        ["valuechange", "change", "input"].forEach((eventName) => {
+          deviceSelect.addEventListener(eventName, persistSelectionAndRefresh);
         });
-      });
+
+        scheduleRefresh();
+      }
+
+      document.addEventListener("DOMContentLoaded", setupDependentRefresh);
+      if (document.readyState !== "loading") setupDependentRefresh();
     </script>
   </body>
 </html>

--- a/src/backend/actions/MusicModeAction.ts
+++ b/src/backend/actions/MusicModeAction.ts
@@ -120,7 +120,12 @@ export class MusicModeAction extends SingletonAction<MusicModeSettings> {
         await this.services.handleRefreshState();
         break;
       case "getMusicModes": {
-        const settings = await ev.action.getSettings();
+        const settings = {
+          ...(await ev.action.getSettings()),
+          ...(typeof ev.payload.selectedDeviceId === "string"
+            ? { selectedDeviceId: ev.payload.selectedDeviceId }
+            : {}),
+        };
         await this.handleGetMusicModes(ev.action.id, settings);
         break;
       }

--- a/src/backend/actions/SnapshotAction.ts
+++ b/src/backend/actions/SnapshotAction.ts
@@ -123,7 +123,12 @@ export class SnapshotAction extends SingletonAction<SnapshotSettings> {
         await this.services.handleRefreshState();
         break;
       case "getSnapshots": {
-        const settings = await ev.action.getSettings();
+        const settings = {
+          ...(await ev.action.getSettings()),
+          ...(typeof ev.payload.selectedDeviceId === "string"
+            ? { selectedDeviceId: ev.payload.selectedDeviceId }
+            : {}),
+        };
         await this.handleGetSnapshots(ev.action.id, settings);
         break;
       }

--- a/src/backend/infrastructure/repositories/GoveeLightRepository.ts
+++ b/src/backend/infrastructure/repositories/GoveeLightRepository.ts
@@ -607,23 +607,100 @@ export class GoveeLightRepository implements ILightRepository {
       );
       if (!device) return [];
 
+      const extractModeValue = (value: unknown): number | null => {
+        if (typeof value === "number" && Number.isInteger(value) && value > 0) {
+          return value;
+        }
+
+        if (typeof value === "object" && value !== null) {
+          if (
+            "musicMode" in value &&
+            typeof value.musicMode === "number" &&
+            Number.isInteger(value.musicMode) &&
+            value.musicMode > 0
+          ) {
+            return value.musicMode;
+          }
+
+          if (
+            "modeId" in value &&
+            typeof value.modeId === "number" &&
+            Number.isInteger(value.modeId) &&
+            value.modeId > 0
+          ) {
+            return value.modeId;
+          }
+
+          if (
+            "id" in value &&
+            typeof value.id === "number" &&
+            Number.isInteger(value.id) &&
+            value.id > 0
+          ) {
+            return value.id;
+          }
+        }
+
+        return null;
+      };
+
+      const dedupe = new Map<number, { name: string; value: number }>();
+
+      const addOptions = (options: unknown[] | undefined) => {
+        if (!Array.isArray(options)) return;
+        for (const option of options) {
+          if (typeof option !== "object" || option === null) continue;
+          const optionRecord = option as { name?: unknown; value?: unknown };
+          const name =
+            typeof optionRecord.name === "string"
+              ? optionRecord.name.trim()
+              : "";
+          const value = extractModeValue(optionRecord.value);
+          if (!name || value === null) continue;
+          dedupe.set(value, { name, value });
+        }
+      };
+
       for (const cap of device.capabilities) {
-        if (cap.instance === "musicMode") {
-          const params = cap.parameters as any;
-          if (params?.fields) {
-            const modeField = params.fields.find(
-              (f: any) => f.fieldName === "musicMode",
+        if (
+          !cap.type.includes("music_setting") ||
+          cap.instance !== "musicMode"
+        ) {
+          continue;
+        }
+
+        const params = cap.parameters as any;
+
+        // Some devices expose music modes directly on parameters.options.
+        addOptions(params?.options);
+
+        // Others expose them under a field, typically alongside sensitivity.
+        if (Array.isArray(params?.fields)) {
+          const preferredFields = params.fields.filter((field: any) => {
+            const fieldName =
+              typeof field?.fieldName === "string"
+                ? field.fieldName.toLowerCase()
+                : "";
+            return (
+              fieldName === "musicmode" ||
+              fieldName === "modeid" ||
+              fieldName === "mode"
             );
-            if (modeField?.options) {
-              return modeField.options.map((o: any) => ({
-                name: String(o.name),
-                value: Number(o.value),
-              }));
-            }
+          });
+
+          for (const field of preferredFields) {
+            addOptions(field?.options);
+          }
+
+          // Fallback for devices that use a different field name but still
+          // carry enumerable mode options in the first field.
+          for (const field of params.fields) {
+            addOptions(field?.options);
           }
         }
       }
-      return [];
+
+      return Array.from(dedupe.values());
     } catch (error) {
       streamDeck.logger.error("Failed to get music modes:", error);
       return [];


### PR DESCRIPTION
# Plugin Pull Request

## Description

Fixes Snapshot and Music Mode dropdown loading for capability-driven devices and reduces repeated dependent-dropdown fetches in the Property Inspector.

Devices such as `H61E5` do not expose snapshot and music mode options through the simplest datasource flow. This PR updates the plugin to consume the corrected shared API client behaviour, ensures the dependent dropdowns request options using the currently selected device and reduces repeated refreshes caused by PI init/settings/device-change overlap.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] 🎨 Style/formatting changes (no code logic changes)
- [ ] ♻️ Code refactoring (no functional changes)
- [ ] ⚡ Performance improvements
- [ ] 🧪 Test additions or modifications
- [ ] 🔧 Build/CI changes
- [ ] 🏗️ Infrastructure changes

## Related Issues

- Related to Snapshot dropdown appearing empty on devices that still support snapshots
- Related to Music Mode dropdown appearing empty on devices that expose music modes through capability fields
- Related to repeated dependent dropdown fetches in the Property Inspector

## Changes Made

- keeps snapshot and music mode enumeration on the shared API client path instead of plugin-local raw API handling
- updates music mode parsing to support nested capability field options returned by the shared client
- keeps Snapshot and Music Mode PI selectors on explicit dependent requests using the current selected device id
- removes temporary action/repository debug logging added during investigation
- reduces repeated dependent requests by guarding PI setup and suppressing duplicate same-device requests

## Screenshots

Not included.

## Testing

### Test Environment

- **OS**: Windows
- **Stream Deck Version**: Not recorded
- **Plugin Version**: 2.2.0
- **Node.js Version**: 24.x

### Test Cases

- [x] Unit tests pass (`npm test`)
- [x] Type checking passes (`npm run type-check`)
- [x] Linting passes (`npm run lint`)
- [x] Build succeeds (`npm run build`)
- [x] DEV build succeeds (`npm run dev:build`)
- [x] Plugin functions as expected in Stream Deck

### Manual Testing Performed

- [x] Property Inspector UI
- [x] State management
- [x] Other: Music Mode enumeration for `H61E5`
- [x] Other: Snapshot enumeration for `H61E5`
- [x] Other: Reduced duplicate dependent dropdown requests

## Performance Impact

- [x] No meaningful performance impact

## Breaking Changes

None.

## Checklist

### Code Quality

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

### Documentation

- [ ] I have updated the README.md if needed
- [ ] I have updated the CONTRIBUTING.md if needed
- [ ] I have added/updated JSDoc comments for new/modified functions
- [ ] I have added/updated examples if applicable

### Backwards Compatibility

- [x] My changes maintain backwards compatibility
- [x] If breaking changes exist, I have documented them above
- [x] I have considered the impact on existing users

### Security

- [x] My changes do not introduce security vulnerabilities
- [x] I have not exposed sensitive information (API keys, credentials, etc.)
- [x] I have followed secure coding practices

## Additional Notes

## Reviewer Guidelines

### For Reviewers

- [ ] Code quality and style
- [ ] Test coverage
- [ ] Documentation completeness
- [ ] Performance considerations
- [ ] Security implications
- [ ] Backwards compatibility
- [ ] Manual testing (if UI changes)

---

**Thank you for contributing to Govee Light Management! 🚀**

Requires [PR](https://github.com/felixgeelhaar/govee-api-client/pull/25)
