### PR TITLE
Filter unsupported Govee cloud groups

### DIFF
--- a/com.felixgeelhaar.govee-light-management.sdPlugin/ui/color.html
+++ b/com.felixgeelhaar.govee-light-management.sdPlugin/ui/color.html
@@ -185,22 +185,78 @@
         function requestPalettes() {
           const client = window.SDPIComponents?.streamDeckClient;
           if (client) {
-            client.send({ event: "getColorPalettes" });
+            if (typeof client.sendToPlugin === "function") {
+              client.sendToPlugin({ event: "getColorPalettes" });
+            } else if (typeof client.send === "function") {
+              client.send("sendToPlugin", { event: "getColorPalettes" });
+            }
           }
         }
 
         function requestRecent() {
           const client = window.SDPIComponents?.streamDeckClient;
           if (client) {
-            client.send({ event: "getRecentColors" });
+            if (typeof client.sendToPlugin === "function") {
+              client.sendToPlugin({ event: "getRecentColors" });
+            } else if (typeof client.send === "function") {
+              client.send("sendToPlugin", { event: "getRecentColors" });
+            }
           }
         }
 
         function clearRecentColors() {
           const client = window.SDPIComponents?.streamDeckClient;
           if (client) {
-            client.send({ event: "clearRecentColors" });
+            if (typeof client.sendToPlugin === "function") {
+              client.sendToPlugin({ event: "clearRecentColors" });
+            } else if (typeof client.send === "function") {
+              client.send("sendToPlugin", { event: "clearRecentColors" });
+            }
           }
+        }
+
+        function toPayload(message) {
+          if (
+            message &&
+            typeof message === "object" &&
+            "payload" in message &&
+            message.payload
+          ) {
+            return message.payload;
+          }
+          return message || {};
+        }
+
+        function subscribePluginMessages(client, onMessage) {
+          const sources = [
+            client && client.sendToPropertyInspector,
+            client && client.message,
+          ].filter(Boolean);
+
+          const subscriptions = [];
+
+          sources.forEach((source) => {
+            if (source && typeof source.subscribe === "function") {
+              const handler = (message) => onMessage(toPayload(message));
+              source.subscribe(handler);
+              subscriptions.push({ source, handler });
+            }
+          });
+
+          if (subscriptions.length > 0) {
+            return () => {
+              subscriptions.forEach(({ source, handler }) => {
+                if (source && typeof source.unsubscribe === "function") {
+                  source.unsubscribe(handler);
+                }
+              });
+            };
+          }
+
+          const legacyHandler = (evt) => onMessage(evt.detail || {});
+          document.addEventListener("sdpi:message", legacyHandler);
+          return () =>
+            document.removeEventListener("sdpi:message", legacyHandler);
         }
 
         function setupListeners() {
@@ -210,7 +266,7 @@
             return;
           }
 
-          client.on?.("sendToPropertyInspector", (payload) => {
+          subscribePluginMessages(client, (payload) => {
             if (!payload || typeof payload !== "object") return;
             if (payload.event === "colorPalettes") {
               renderPalettes(payload.items || []);

--- a/com.felixgeelhaar.govee-light-management.sdPlugin/ui/js/setup.js
+++ b/com.felixgeelhaar.govee-light-management.sdPlugin/ui/js/setup.js
@@ -17,6 +17,11 @@ document.addEventListener("DOMContentLoaded", () => {
     colorTemp: document.getElementById("tempItem"),
   };
   const hasConditionalItems = Object.values(conditionalItems).some(Boolean);
+  const UNSUPPORTED_CLOUD_GROUP_MODELS = new Set([
+    "BaseGroup",
+    "SameModelGroup",
+    "SameModeGroup",
+  ]);
   let latestSettings = {};
   let selectedDeviceDebug = null;
   let selectedDeviceDebugId = "";
@@ -643,6 +648,35 @@ document.addEventListener("DOMContentLoaded", () => {
       'sdpi-select[setting="selectedDeviceId"]',
     );
     if (!deviceSelect) return;
+    const unsupportedHint = document.createElement("div");
+    unsupportedHint.id = "deviceUnsupported";
+    unsupportedHint.className = "field-hint error hidden";
+    deviceSelect.parentNode.insertBefore(unsupportedHint, deviceSelect.nextSibling);
+
+    function getSelectedModel(selectedDeviceId) {
+      if (typeof selectedDeviceId !== "string") return "";
+      if (!selectedDeviceId.startsWith("light:")) return "";
+      const raw = selectedDeviceId.substring(6);
+      const parts = raw.split("|");
+      return parts.length >= 2 ? parts[1] : "";
+    }
+
+    function updateUnsupportedHint() {
+      const selectedDeviceId =
+        deviceSelect.value ||
+        (typeof latestSettings?.selectedDeviceId === "string"
+          ? latestSettings.selectedDeviceId
+          : "");
+      const model = getSelectedModel(selectedDeviceId);
+      if (UNSUPPORTED_CLOUD_GROUP_MODELS.has(model)) {
+        unsupportedHint.textContent =
+          "Govee cloud groups like BaseGroup / SameModelGroup are not supported. Use a plugin group instead.";
+        unsupportedHint.className = "field-hint error";
+      } else {
+        unsupportedHint.textContent = "";
+        unsupportedHint.className = "field-hint error hidden";
+      }
+    }
 
     const rerenderDebug = () => {
       const selectedDeviceId = deviceSelect.value || "";
@@ -651,6 +685,7 @@ document.addEventListener("DOMContentLoaded", () => {
         ...latestSettings,
         selectedDeviceId,
       };
+      updateUnsupportedHint();
       renderDebugInfo();
       requestSelectedDeviceDebug(client);
     };
@@ -688,11 +723,14 @@ document.addEventListener("DOMContentLoaded", () => {
         clearTimeout(timer);
         const hint = document.getElementById("deviceTimeout");
         if (hint) hint.remove();
+        updateUnsupportedHint();
         renderDebugInfo();
         requestSelectedDeviceDebug(client);
         unsubscribeMessages();
       }
     });
+
+    updateUnsupportedHint();
   }
 
   // ── Field Status Hints ──

--- a/src/backend/connectivity/cloud/CloudTransport.ts
+++ b/src/backend/connectivity/cloud/CloudTransport.ts
@@ -33,6 +33,12 @@ const factory: ClientFactory = {
   },
 };
 
+const UNSUPPORTED_CLOUD_GROUP_MODELS = new Set([
+  "BaseGroup",
+  "SameModelGroup",
+  "SameModeGroup",
+]);
+
 export class CloudTransport implements ITransport {
   readonly descriptor: TransportDescriptor = {
     kind: TransportKind.Cloud,
@@ -72,7 +78,13 @@ export class CloudTransport implements ITransport {
   async discoverDevices(): Promise<DeviceDiscoveryResult> {
     try {
       const client = await this.ensureClient();
-      const devices = await client.getControllableDevices();
+      const devices = await client
+        .getControllableDevices()
+        .then((entries) =>
+          entries.filter(
+            (device) => !UNSUPPORTED_CLOUD_GROUP_MODELS.has(device.model),
+          ),
+        );
       const lights: LightItem[] = devices.map((device) => {
         // Detect advanced capabilities from the device's capability list
         const capInstances = new Set(

--- a/src/backend/infrastructure/repositories/GoveeLightRepository.ts
+++ b/src/backend/infrastructure/repositories/GoveeLightRepository.ts
@@ -25,6 +25,12 @@ import {
 import { safeGetColorTemperature } from "../utils/deviceStateUtils";
 import streamDeck from "@elgato/streamdeck";
 
+const UNSUPPORTED_CLOUD_GROUP_MODELS = new Set([
+  "BaseGroup",
+  "SameModelGroup",
+  "SameModeGroup",
+]);
+
 export class GoveeLightRepository implements ILightRepository {
   private client: GoveeClient;
 
@@ -40,7 +46,13 @@ export class GoveeLightRepository implements ILightRepository {
 
   async getAllLights(): Promise<Light[]> {
     try {
-      const devices = await this.client.getControllableDevices();
+      const devices = await this.client
+        .getControllableDevices()
+        .then((entries) =>
+          entries.filter(
+            (device) => !UNSUPPORTED_CLOUD_GROUP_MODELS.has(device.model),
+          ),
+        );
       return devices.map((device) => this.mapDeviceToLight(device));
     } catch (error) {
       streamDeck.logger.error("Failed to fetch lights from Govee API:", error);
@@ -52,7 +64,13 @@ export class GoveeLightRepository implements ILightRepository {
 
   async findLight(deviceId: string, model: string): Promise<Light | null> {
     try {
-      const devices = await this.client.getControllableDevices();
+      const devices = await this.client
+        .getControllableDevices()
+        .then((entries) =>
+          entries.filter(
+            (device) => !UNSUPPORTED_CLOUD_GROUP_MODELS.has(device.model),
+          ),
+        );
       const device = devices.find(
         (d) => d.deviceId === deviceId && d.model === model,
       );
@@ -72,7 +90,13 @@ export class GoveeLightRepository implements ILightRepository {
 
   async findLightsByName(name: string): Promise<Light[]> {
     try {
-      const devices = await this.client.getControllableDevices();
+      const devices = await this.client
+        .getControllableDevices()
+        .then((entries) =>
+          entries.filter(
+            (device) => !UNSUPPORTED_CLOUD_GROUP_MODELS.has(device.model),
+          ),
+        );
       const matchingDevices = devices.filter((device) =>
         device.deviceName.toLowerCase().includes(name.toLowerCase()),
       );

--- a/test/backend/connectivity/CloudTransport.test.ts
+++ b/test/backend/connectivity/CloudTransport.test.ts
@@ -152,4 +152,39 @@ describe("CloudTransport.discoverDevices", () => {
     const { lights } = await transport.discoverDevices();
     expect(lights[0]?.capabilities?.colorTemperature).toBe(true);
   });
+
+  it("filters unsupported cloud group pseudo-devices from discovery", async () => {
+    const realLight = buildDevice({
+      deviceId: "light-1",
+      model: "H6001",
+      deviceName: "Desk Light",
+    });
+    const sameModelGroup = buildDevice({
+      deviceId: "group-1",
+      model: "SameModelGroup",
+      deviceName: "Bedroom Group",
+    });
+    const baseGroup = buildDevice({
+      deviceId: "group-2",
+      model: "BaseGroup",
+      deviceName: "All Lights",
+    });
+
+    const transport = new CloudTransport({
+      factory: {
+        create: () =>
+          ({
+            getControllableDevices: vi
+              .fn()
+              .mockResolvedValue([realLight, sameModelGroup, baseGroup]),
+          }) as never,
+      },
+    });
+
+    const { lights } = await transport.discoverDevices();
+
+    expect(lights).toHaveLength(1);
+    expect(lights[0]?.deviceId).toBe("light-1");
+    expect(lights[0]?.model).toBe("H6001");
+  });
 });


### PR DESCRIPTION
Prevents unsupported Govee cloud pseudo-group entries from being treated as normal lights and improves the Property Inspector feedback when those stale selections are still configured.

This change:

filters unsupported cloud group models such as BaseGroup, SameModelGroup, and SameModeGroup from device discovery keeps those pseudo-group entries from appearing in action dropdowns as selectable lights adds an explicit Property Inspector warning when an existing action is still bound to one of those unsupported cloud group selections fixes the Color action preset/recent palette loading by replacing the legacy Property Inspector messaging flow with the current sendToPlugin / sendToPropertyInspector subscription pattern reverts the experimental grouped command fallback so normal light and plugin-group actions stay on the original control path This addresses cases where Govee cloud group entries were exposed by the device API but did not behave like real controllable lights in the plugin, leading to broken actions and misleading selections.

# Pull Request

## Description

Prevents unsupported Govee cloud pseudo-group entries from being treated as normal lights and improves Property Inspector feedback for stale selections that still reference them.

Some Govee accounts expose cloud group objects such as `BaseGroup`, `SameModelGroup`, and `SameModeGroup` in the device list. These entries are not handled like real lights by the plugin, but they were still being surfaced in device dropdowns and could be selected by actions. This caused broken behavior when users tried to control them and made it look like normal light actions were failing.

This PR filters those unsupported cloud group models out of discovery, keeps them out of action dropdowns, adds a clear Property Inspector warning when an existing action is still bound to one of those stale selections, and fixes the Color Property Inspector preset/recent palette loading by moving it off the old legacy PI messaging pattern.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] 🎨 Style/formatting changes (no code logic changes)
- [ ] ♻️ Code refactoring (no functional changes)
- [ ] ⚡ Performance improvements
- [ ] 🧪 Test additions or modifications
- [ ] 🔧 Build/CI changes
- [ ] 🏗️ Infrastructure changes

## Related Issues

- Related to unsupported Govee cloud group entries being surfaced as normal device selections
- Related to actions failing when bound to `BaseGroup` / `SameModelGroup` style cloud pseudo-groups
- Related to Color Property Inspector preset loading getting stuck on `Loading palettes...`
- #188 #186 

## Changes Made

- filters unsupported cloud group models such as `BaseGroup`, `SameModelGroup`, and `SameModeGroup` from cloud device discovery
- filters those unsupported models from repository-level light lookups so they are not treated as controllable lights
- adds a shared Property Inspector warning when an existing action is still bound to one of those unsupported cloud group selections
- keeps unsupported cloud pseudo-group entries out of refreshed device dropdowns across actions
- fixes the Color Property Inspector preset and recent color loading by replacing the legacy PI messaging flow with the current `sendToPlugin` / `sendToPropertyInspector` subscription pattern
- reverts the temporary grouped-command experiment so real lights and plugin-created groups remain on the original control path

## Screenshots

Not included.

## Testing

### Test Environment

- **OS**: Windows
- **Stream Deck Version**: Not recorded
- **Plugin Version**: 2.2.0
- **Node.js Version**: 24.x

### Test Cases

- [x] Unit tests pass (`npm test -- CloudTransport LightControlService`)
- [x] Type checking passes (`npm run type-check`)
- [x] Linting passes (`npm run lint`)
- [x] Build succeeds (`npm run build`)
- [x] DEV build succeeds (`npm run dev:build`)
- [x] Plugin functions as expected in Stream Deck

### Manual Testing Performed

- [x] Property Inspector UI
- [x] Other: Unsupported cloud group models no longer appear as normal selectable devices after refresh
- [x] Other: Existing stale unsupported cloud-group selections show a clear PI warning
- [x] Other: Color presets/recent palette loading no longer relies on the broken legacy PI messaging path

## Performance Impact

- [x] No meaningful performance impact

## Breaking Changes

None.

## Checklist

### Code Quality

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing targeted unit tests pass locally with my changes

### Documentation

- [ ] I have updated the README.md if needed
- [ ] I have updated the CONTRIBUTING.md if needed
- [ ] I have added/updated JSDoc comments for new/modified functions
- [ ] I have added/updated examples if applicable

### Backwards Compatibility

- [x] My changes maintain backwards compatibility
- [x] If breaking changes exist, I have documented them above
- [x] I have considered the impact on existing users

### Security

- [x] My changes do not introduce security vulnerabilities
- [x] I have not exposed sensitive information (API keys, credentials, etc.)
- [x] I have followed secure coding practices

## Additional Notes

## Reviewer Guidelines

### For Reviewers

- [ ] Code quality and style
- [ ] Test coverage
- [ ] Documentation completeness
- [ ] Performance considerations
- [ ] Security implications
- [ ] Backwards compatibility
- [ ] Manual testing (if UI changes)

---

**Thank you for contributing to Govee Light Management! 🚀**
