### PR TITLE
chore: add compile-time + E2E guardrails for PI datasource responses

### DIFF
--- a/src/backend/actions/CustomEffectAction.ts
+++ b/src/backend/actions/CustomEffectAction.ts
@@ -10,7 +10,7 @@ import {
 import type { JsonValue } from "@elgato/utils";
 import {
   ActionServices,
-  sendToPI,
+  sendPIDatasource,
   type BaseSettings,
 } from "./shared/ActionServices";
 import { effectService } from "../services/EffectService";
@@ -101,8 +101,18 @@ export class CustomEffectAction extends SingletonAction<CustomEffectSettings> {
       value: e.id,
       label: e.name,
     }));
-    await sendToPI(actionId, {
+    if (effects.length === 0) {
+      await sendPIDatasource(actionId, {
+        event: "getEffects",
+        status: "empty",
+        items: [],
+        message: "No effects available.",
+      });
+      return;
+    }
+    await sendPIDatasource(actionId, {
       event: "getEffects",
+      status: "ok",
       items: effects,
     });
   }

--- a/src/backend/actions/MusicModeAction.ts
+++ b/src/backend/actions/MusicModeAction.ts
@@ -12,7 +12,7 @@ import type { JsonValue } from "@elgato/utils";
 import { MusicMode } from "@felixgeelhaar/govee-api-client";
 import {
   ActionServices,
-  sendToPI,
+  sendPIDatasource,
   type BaseSettings,
 } from "./shared/ActionServices";
 
@@ -141,7 +141,7 @@ export class MusicModeAction extends SingletonAction<MusicModeSettings> {
   ): Promise<void> {
     const deviceId = settings.selectedDeviceId;
     if (!deviceId) {
-      await sendToPI(actionId, {
+      await sendPIDatasource(actionId, {
         event: "getMusicModes",
         items: [],
         status: "empty",
@@ -153,7 +153,7 @@ export class MusicModeAction extends SingletonAction<MusicModeSettings> {
     try {
       const apiKey = await this.services.getApiKey(settings);
       if (!apiKey) {
-        await sendToPI(actionId, {
+        await sendPIDatasource(actionId, {
           event: "getMusicModes",
           items: [],
           status: "error",
@@ -178,7 +178,7 @@ export class MusicModeAction extends SingletonAction<MusicModeSettings> {
 
       const modes = await this.services.getMusicModes(queryDeviceId);
       if (modes.length === 0) {
-        await sendToPI(actionId, {
+        await sendPIDatasource(actionId, {
           event: "getMusicModes",
           items: [],
           status: "empty",
@@ -186,7 +186,7 @@ export class MusicModeAction extends SingletonAction<MusicModeSettings> {
         });
         return;
       }
-      await sendToPI(actionId, {
+      await sendPIDatasource(actionId, {
         event: "getMusicModes",
         status: "ok",
         items: modes.map((m) => ({
@@ -196,7 +196,7 @@ export class MusicModeAction extends SingletonAction<MusicModeSettings> {
       });
     } catch (error) {
       streamDeck.logger.error("Failed to fetch music modes:", error);
-      await sendToPI(actionId, {
+      await sendPIDatasource(actionId, {
         event: "getMusicModes",
         items: [],
         status: "error",

--- a/src/backend/actions/SceneAction.ts
+++ b/src/backend/actions/SceneAction.ts
@@ -12,7 +12,7 @@ import type { JsonValue } from "@elgato/utils";
 import { DiyScene, LightScene } from "@felixgeelhaar/govee-api-client";
 import {
   ActionServices,
-  sendToPI,
+  sendPIDatasource,
   type BaseSettings,
 } from "./shared/ActionServices";
 import { buildSceneItems } from "./scene-items";
@@ -169,7 +169,7 @@ export class SceneAction extends SingletonAction<SceneSettings> {
   ): Promise<void> {
     const deviceId = settings.selectedDeviceId;
     if (!deviceId) {
-      await sendToPI(actionId, {
+      await sendPIDatasource(actionId, {
         event: "getScenes",
         items: [],
         status: "empty",
@@ -181,7 +181,7 @@ export class SceneAction extends SingletonAction<SceneSettings> {
     try {
       const apiKey = await this.services.getApiKey(settings ?? {});
       if (!apiKey) {
-        await sendToPI(actionId, {
+        await sendPIDatasource(actionId, {
           event: "getScenes",
           items: [],
           status: "error",
@@ -207,7 +207,7 @@ export class SceneAction extends SingletonAction<SceneSettings> {
       }
 
       if (!queryLight) {
-        await sendToPI(actionId, {
+        await sendPIDatasource(actionId, {
           event: "getScenes",
           items: [],
           status: "error",
@@ -223,7 +223,7 @@ export class SceneAction extends SingletonAction<SceneSettings> {
       ]);
       const items = buildSceneItems(dynamicScenes, diyScenes);
       if (items.length === 0) {
-        await sendToPI(actionId, {
+        await sendPIDatasource(actionId, {
           event: "getScenes",
           items: [],
           status: "empty",
@@ -232,14 +232,14 @@ export class SceneAction extends SingletonAction<SceneSettings> {
         });
         return;
       }
-      await sendToPI(actionId, {
+      await sendPIDatasource(actionId, {
         event: "getScenes",
         status: "ok",
         items,
       });
     } catch (error) {
       streamDeck.logger.error("Failed to fetch scenes:", error);
-      await sendToPI(actionId, {
+      await sendPIDatasource(actionId, {
         event: "getScenes",
         items: [],
         status: "error",

--- a/src/backend/actions/SnapshotAction.ts
+++ b/src/backend/actions/SnapshotAction.ts
@@ -12,7 +12,7 @@ import type { JsonValue } from "@elgato/utils";
 import { Snapshot } from "@felixgeelhaar/govee-api-client";
 import {
   ActionServices,
-  sendToPI,
+  sendPIDatasource,
   type BaseSettings,
 } from "./shared/ActionServices";
 
@@ -144,7 +144,7 @@ export class SnapshotAction extends SingletonAction<SnapshotSettings> {
   ): Promise<void> {
     const deviceId = settings.selectedDeviceId;
     if (!deviceId) {
-      await sendToPI(actionId, {
+      await sendPIDatasource(actionId, {
         event: "getSnapshots",
         items: [],
         status: "empty",
@@ -156,7 +156,7 @@ export class SnapshotAction extends SingletonAction<SnapshotSettings> {
     try {
       const apiKey = await this.services.getApiKey(settings ?? {});
       if (!apiKey) {
-        await sendToPI(actionId, {
+        await sendPIDatasource(actionId, {
           event: "getSnapshots",
           items: [],
           status: "error",
@@ -180,7 +180,7 @@ export class SnapshotAction extends SingletonAction<SnapshotSettings> {
       }
 
       if (!queryLight) {
-        await sendToPI(actionId, {
+        await sendPIDatasource(actionId, {
           event: "getSnapshots",
           items: [],
           status: "error",
@@ -192,7 +192,7 @@ export class SnapshotAction extends SingletonAction<SnapshotSettings> {
 
       const snapshots = await this.services.getSnapshots(queryLight);
       if (snapshots.length === 0) {
-        await sendToPI(actionId, {
+        await sendPIDatasource(actionId, {
           event: "getSnapshots",
           items: [],
           status: "empty",
@@ -201,7 +201,7 @@ export class SnapshotAction extends SingletonAction<SnapshotSettings> {
         });
         return;
       }
-      await sendToPI(actionId, {
+      await sendPIDatasource(actionId, {
         event: "getSnapshots",
         status: "ok",
         items: snapshots.map((s) => ({
@@ -215,7 +215,7 @@ export class SnapshotAction extends SingletonAction<SnapshotSettings> {
       });
     } catch (error) {
       streamDeck.logger.error("Failed to fetch snapshots:", error);
-      await sendToPI(actionId, {
+      await sendPIDatasource(actionId, {
         event: "getSnapshots",
         items: [],
         status: "error",

--- a/src/backend/actions/ToggleAction.ts
+++ b/src/backend/actions/ToggleAction.ts
@@ -11,7 +11,7 @@ import {
 import type { JsonValue } from "@elgato/utils";
 import {
   ActionServices,
-  sendToPI,
+  sendPIDatasource,
   type BaseSettings,
 } from "./shared/ActionServices";
 import { parseFeatureSetting } from "./shared/validation";
@@ -219,7 +219,7 @@ export class ToggleAction extends SingletonAction<ToggleSettings> {
   ): Promise<void> {
     const deviceId = settings.selectedDeviceId;
     if (!deviceId) {
-      await sendToPI(actionId, {
+      await sendPIDatasource(actionId, {
         event: "getToggleFeatures",
         items: [],
         status: "empty",
@@ -231,7 +231,7 @@ export class ToggleAction extends SingletonAction<ToggleSettings> {
     try {
       const apiKey = await this.services.getApiKey(settings);
       if (!apiKey) {
-        await sendToPI(actionId, {
+        await sendPIDatasource(actionId, {
           event: "getToggleFeatures",
           items: [],
           status: "error",
@@ -256,7 +256,7 @@ export class ToggleAction extends SingletonAction<ToggleSettings> {
 
       const features = await this.services.getToggleFeatures(queryDeviceId);
       if (features.length === 0) {
-        await sendToPI(actionId, {
+        await sendPIDatasource(actionId, {
           event: "getToggleFeatures",
           items: [],
           status: "empty",
@@ -264,7 +264,7 @@ export class ToggleAction extends SingletonAction<ToggleSettings> {
         });
         return;
       }
-      await sendToPI(actionId, {
+      await sendPIDatasource(actionId, {
         event: "getToggleFeatures",
         status: "ok",
         items: features.map((f) => ({
@@ -274,7 +274,7 @@ export class ToggleAction extends SingletonAction<ToggleSettings> {
       });
     } catch (error) {
       streamDeck.logger.error("Failed to fetch toggle features:", error);
-      await sendToPI(actionId, {
+      await sendPIDatasource(actionId, {
         event: "getToggleFeatures",
         items: [],
         status: "error",

--- a/src/backend/actions/shared/ActionServices.ts
+++ b/src/backend/actions/shared/ActionServices.ts
@@ -116,7 +116,50 @@ function withTimeout<T>(
   });
 }
 
-export { sendToPI };
+/**
+ * Status discriminator for any datasource-style response the plugin sends
+ * to the Property Inspector. Every backend datasource handler MUST emit
+ * one of these so the PI can distinguish an empty result from a failure
+ * from a valid-but-empty state, and surface the right hint to the user.
+ *
+ * Introduced after #182, where silent `items: []` responses were
+ * indistinguishable from genuine empties and left users staring at a
+ * stale "Select a device first" placeholder.
+ */
+export type PIDatasourceStatus = "ok" | "empty" | "error";
+
+export interface PIDatasourceItem {
+  label: string;
+  value: string;
+  /** Optional nested-group items for SDPI optgroup-style dropdowns. */
+  children?: PIDatasourceItem[];
+}
+
+export interface PIDatasourceResponse<E extends string = string> {
+  event: E;
+  status: PIDatasourceStatus;
+  items: PIDatasourceItem[];
+  /**
+   * Human-readable hint shown below the dropdown when the status is
+   * `empty` or `error`. Optional for `ok` responses.
+   */
+  message?: string;
+}
+
+/**
+ * Typed wrapper around `sendToPI` for datasource-style responses. Requires
+ * the caller to include a `status` field at compile time so we can never
+ * again ship a handler that silently returns `items: []` without
+ * signalling why.
+ */
+async function sendPIDatasource<E extends string>(
+  actionId: string,
+  response: PIDatasourceResponse<E>,
+): Promise<void> {
+  await sendToPI(actionId, response as unknown as Record<string, unknown>);
+}
+
+export { sendToPI, sendPIDatasource };
 
 export interface DeviceTarget {
   type: "light" | "group";
@@ -483,21 +526,17 @@ export class ActionServices {
         streamDeck.logger.warn(
           "handleGetDevices: no API key in global settings",
         );
-        await sendToPI(actionId, {
+        await sendPIDatasource(actionId, {
           event: "getDevices",
-          items: [],
           status: "error",
+          items: [],
           message: "Missing API key — reconnect in the API Key panel.",
         });
         return;
       }
 
       await this.ensureServices(apiKey);
-      const items: Array<{
-        label: string;
-        value: string;
-        children?: Array<{ label: string; value: string }>;
-      }> = [];
+      const items: PIDatasourceItem[] = [];
 
       let discoveryFailed = false;
 
@@ -509,12 +548,10 @@ export class ActionServices {
             PI_HANDLER_TIMEOUT_MS,
             "Device discovery",
           );
-          const lightItems = lights.map((light) => {
-            return {
-              label: `${light.label ?? light.name} (${light.model})`,
-              value: `light:${light.deviceId}|${light.model}`,
-            };
-          });
+          const lightItems: PIDatasourceItem[] = lights.map((light) => ({
+            label: `${light.label ?? light.name} (${light.model})`,
+            value: `light:${light.deviceId}|${light.model}`,
+          }));
 
           if (lightItems.length > 0) {
             items.push({
@@ -539,7 +576,7 @@ export class ActionServices {
       // Add groups
       if (this.groupService) {
         const groups = await this.groupService.getAllGroups();
-        const groupItems = groups.map((g) => ({
+        const groupItems: PIDatasourceItem[] = groups.map((g) => ({
           label: `${g.name} (${g.size} lights)`,
           value: `group:${g.id}`,
         }));
@@ -557,27 +594,27 @@ export class ActionServices {
         `handleGetDevices: sending ${items.length} item groups to PI`,
       );
       if (items.length === 0) {
-        await sendToPI(actionId, {
+        await sendPIDatasource(actionId, {
           event: "getDevices",
-          items: [],
           status: discoveryFailed ? "error" : "empty",
+          items: [],
           message: discoveryFailed
             ? "Failed to load devices. Check your API key and connection."
             : "No devices found. Add lights in the Govee mobile app, then refresh.",
         });
         return;
       }
-      await sendToPI(actionId, {
+      await sendPIDatasource(actionId, {
         event: "getDevices",
-        items,
         status: "ok",
+        items,
       });
     } catch (error) {
       streamDeck.logger.error("Failed to fetch devices:", error);
-      await sendToPI(actionId, {
+      await sendPIDatasource(actionId, {
         event: "getDevices",
-        items: [],
         status: "error",
+        items: [],
         message: "Failed to load devices. Check your API key and connection.",
       });
     }

--- a/test/e2e/dependent-dropdowns.spec.ts
+++ b/test/e2e/dependent-dropdowns.spec.ts
@@ -1,0 +1,92 @@
+/**
+ * E2E tests for Property Inspectors that have a second dropdown
+ * depending on the selected device (Scene, Snapshot, Music Mode, Toggle,
+ * Custom Effect). Verifies the datasource wiring is correct so we never
+ * ship a dropdown that silently fails to load options (see #184 Custom
+ * Effect regression and #182 snapshot empty-state bug).
+ */
+import { test, expect } from "@playwright/test";
+
+const DEPENDENT_PIS = [
+  {
+    name: "Scene",
+    url: "/ui/scene.html",
+    dependent: { setting: "selectedScene", datasource: "getScenes" },
+  },
+  {
+    name: "Snapshot",
+    url: "/ui/snapshot.html",
+    dependent: { setting: "selectedSnapshot", datasource: "getSnapshots" },
+  },
+  {
+    name: "Music Mode",
+    url: "/ui/music-mode.html",
+    dependent: { setting: "selectedMode", datasource: "getMusicModes" },
+  },
+  {
+    name: "Toggle",
+    url: "/ui/toggle.html",
+    dependent: { setting: "selectedFeature", datasource: "getToggleFeatures" },
+  },
+  {
+    name: "Custom Effect",
+    url: "/ui/custom-effect.html",
+    dependent: { setting: "effectId", datasource: "getEffects" },
+  },
+];
+
+for (const { name, url, dependent } of DEPENDENT_PIS) {
+  test.describe(`${name} Property Inspector`, () => {
+    test.beforeEach(async ({ page }) => {
+      await page.goto(url);
+    });
+
+    test("should have setup and settings panels", async ({ page }) => {
+      await expect(page.locator("#setup")).toBeAttached();
+      await expect(page.locator("#settings")).toBeAttached();
+    });
+
+    test("should have API key input and Connect button", async ({ page }) => {
+      await expect(page.locator("#apiKey")).toBeAttached();
+      await expect(page.locator("#connect")).toBeAttached();
+    });
+
+    test("should have device selector bound to getDevices", async ({
+      page,
+    }) => {
+      const select = page.locator('sdpi-select[setting="selectedDeviceId"]');
+      await expect(select).toBeAttached();
+      await expect(select).toHaveAttribute("datasource", "getDevices");
+    });
+
+    test(`should have dependent dropdown bound to ${dependent.datasource}`, async ({
+      page,
+    }) => {
+      const select = page.locator(
+        `sdpi-select[setting="${dependent.setting}"]`,
+      );
+      await expect(select).toBeAttached();
+      await expect(select).toHaveAttribute("datasource", dependent.datasource);
+    });
+
+    test("should load without console errors", async ({ page }) => {
+      const errors: string[] = [];
+      page.on("pageerror", (err) => errors.push(err.message));
+      page.on("console", (msg) => {
+        if (msg.type() === "error") errors.push(msg.text());
+      });
+      // Reload so our listeners observe the full page lifecycle.
+      await page.goto(url);
+      await page.waitForLoadState("domcontentloaded");
+      // Filter out expected SDPI connection warnings that fire when the
+      // PI loads outside Stream Deck's WebSocket environment.
+      const unexpected = errors.filter(
+        (e) =>
+          !/sendToPlugin is unavailable/i.test(e) &&
+          !/WebSocket/i.test(e) &&
+          !/streamDeckClient/i.test(e),
+      );
+      expect(unexpected).toEqual([]);
+    });
+  });
+}

--- a/test/e2e/dial-actions.spec.ts
+++ b/test/e2e/dial-actions.spec.ts
@@ -7,6 +7,8 @@ const DIAL_PIS = [
   { name: 'Brightness Dial', url: '/ui/brightness-dial.html', settings: ['stepSize'] },
   { name: 'Color Hue Dial', url: '/ui/colorhue-dial.html', settings: ['saturation', 'stepSize'] },
   { name: 'Color Temperature Dial', url: '/ui/colortemp-dial.html', settings: ['stepSize'] },
+  { name: 'Saturation Dial', url: '/ui/saturation-dial.html', settings: ['stepSize'] },
+  { name: 'Segment Color Dial', url: '/ui/segment-color-dial.html', settings: ['segmentIndex', 'saturation', 'stepSize'] },
 ];
 
 for (const { name, url, settings } of DIAL_PIS) {

--- a/test/e2e/feature-pis.spec.ts
+++ b/test/e2e/feature-pis.spec.ts
@@ -1,0 +1,101 @@
+/**
+ * E2E smoke tests for the remaining feature Property Inspectors that
+ * don't fit the simple keypad or dial templates: Segment Color,
+ * Schedule, Sequence. Verifies core wiring (setup/settings panels,
+ * API key flow, device dropdown datasource) so a broken PI never
+ * ships silently.
+ */
+import { test, expect } from "@playwright/test";
+
+const FEATURE_PIS = [
+  {
+    name: "Segment Color",
+    url: "/ui/segment-color.html",
+    hasDeviceSelect: true,
+    extraSelects: ["preset"],
+    extraRanges: ["segmentStart", "segmentEnd"],
+  },
+  {
+    name: "Schedule",
+    url: "/ui/schedule.html",
+    hasDeviceSelect: true,
+    extraSelects: ["scheduleType", "command"],
+    extraRanges: [],
+  },
+  {
+    name: "Sequence",
+    url: "/ui/sequence.html",
+    // Sequence uses its own builder; device dropdown lives inside the
+    // step builder, not at top level.
+    hasDeviceSelect: false,
+    extraSelects: [],
+    extraRanges: [],
+  },
+];
+
+for (const {
+  name,
+  url,
+  hasDeviceSelect,
+  extraSelects,
+  extraRanges,
+} of FEATURE_PIS) {
+  test.describe(`${name} Property Inspector`, () => {
+    test.beforeEach(async ({ page }) => {
+      await page.goto(url);
+    });
+
+    test("should have setup and settings panels", async ({ page }) => {
+      await expect(page.locator("#setup")).toBeAttached();
+      await expect(page.locator("#settings")).toBeAttached();
+    });
+
+    test("should have API key input and Connect button", async ({ page }) => {
+      await expect(page.locator("#apiKey")).toBeAttached();
+      await expect(page.locator("#connect")).toBeAttached();
+    });
+
+    if (hasDeviceSelect) {
+      test("should have device selector bound to getDevices", async ({
+        page,
+      }) => {
+        const select = page.locator('sdpi-select[setting="selectedDeviceId"]');
+        await expect(select).toBeAttached();
+        await expect(select).toHaveAttribute("datasource", "getDevices");
+      });
+    }
+
+    for (const setting of extraSelects) {
+      test(`should have ${setting} select`, async ({ page }) => {
+        await expect(
+          page.locator(`sdpi-select[setting="${setting}"]`),
+        ).toBeAttached();
+      });
+    }
+
+    for (const setting of extraRanges) {
+      test(`should have ${setting} range`, async ({ page }) => {
+        await expect(
+          page.locator(`sdpi-range[setting="${setting}"]`),
+        ).toBeAttached();
+      });
+    }
+
+    test("should load without unexpected errors", async ({ page }) => {
+      const errors: string[] = [];
+      page.on("pageerror", (err) => errors.push(err.message));
+      page.on("console", (msg) => {
+        if (msg.type() === "error") errors.push(msg.text());
+      });
+      await page.goto(url);
+      await page.waitForLoadState("domcontentloaded");
+      const unexpected = errors.filter(
+        (e) =>
+          !/sendToPlugin is unavailable/i.test(e) &&
+          !/WebSocket/i.test(e) &&
+          !/streamDeckClient/i.test(e),
+      );
+      expect(unexpected).toEqual([]);
+    });
+  });
+}

--- a/test/e2e/field-hints.spec.ts
+++ b/test/e2e/field-hints.spec.ts
@@ -1,0 +1,186 @@
+/**
+ * E2E behavior tests for the shared field-hint system.
+ *
+ * Proves that a backend datasource response carrying `status: "empty"`
+ * or `status: "error"` renders a visible hint element below the
+ * dependent dropdown, rather than leaving the user staring at the
+ * static "Select a device first" placeholder (the bug in #182).
+ *
+ * Uses page.addInitScript to inject a mock SDPIComponents.streamDeckClient
+ * before the PI's DOMContentLoaded handler runs, then captures the
+ * subscribe() handler and invokes it with synthetic payloads.
+ */
+import { test, expect, type Page } from "@playwright/test";
+
+async function installMockClient(page: Page) {
+  await page.addInitScript(() => {
+    type Handler = (msg: unknown) => void;
+    type WrappedMessage = { payload: unknown };
+
+    const piHandlers: Handler[] = [];
+
+    const subscribable = <T>(handlers: Handler[]) => ({
+      subscribe(handler: (msg: T) => void) {
+        handlers.push(handler as Handler);
+      },
+      unsubscribe(handler: (msg: T) => void) {
+        const idx = handlers.indexOf(handler as Handler);
+        if (idx >= 0) handlers.splice(idx, 1);
+      },
+    });
+
+    const globalSettingsHandlers: Handler[] = [];
+    const settingsHandlers: Handler[] = [];
+
+    const client = {
+      sendToPropertyInspector: subscribable<WrappedMessage>(piHandlers),
+      didReceiveGlobalSettings: subscribable(globalSettingsHandlers),
+      didReceiveSettings: subscribable(settingsHandlers),
+      getGlobalSettings() {
+        // Simulate an empty global settings response so the PI shows
+        // the API key setup panel (consistent with first-run state).
+        setTimeout(() => {
+          globalSettingsHandlers.forEach((h) =>
+            h({ payload: { settings: {} } }),
+          );
+        }, 0);
+      },
+      setGlobalSettings() {},
+      sendToPlugin() {},
+      send() {},
+    };
+
+    // Expose hook for tests to dispatch PI messages into the subscribed
+    // handlers as if they came from the plugin backend.
+    (
+      window as unknown as {
+        __dispatchPIMessage: (payload: unknown) => void;
+      }
+    ).__dispatchPIMessage = (payload: unknown) => {
+      piHandlers.forEach((h) => h({ payload }));
+    };
+
+    // Use a property descriptor so that if sdpi-components.js tries to
+    // replace window.SDPIComponents later, our mock still wins.
+    Object.defineProperty(window, "SDPIComponents", {
+      get: () => ({ streamDeckClient: client }),
+      set: () => {
+        /* swallow assignments from the real library */
+      },
+      configurable: true,
+    });
+  });
+}
+
+async function dispatchPIMessage(page: Page, payload: unknown) {
+  await page.evaluate((p) => {
+    (
+      window as unknown as { __dispatchPIMessage: (payload: unknown) => void }
+    ).__dispatchPIMessage(p);
+  }, payload);
+}
+
+const HINT_SCENARIOS = [
+  {
+    name: "Snapshot",
+    url: "/ui/snapshot.html",
+    event: "getSnapshots",
+    emptyMessage: "No snapshots found. Create one in the Govee mobile app first.",
+    errorMessage: "Couldn't load snapshots. Check your connection and try again.",
+  },
+  {
+    name: "Scene",
+    url: "/ui/scene.html",
+    event: "getScenes",
+    emptyMessage: "This device has no dynamic scenes available.",
+    errorMessage: "Couldn't load scenes. Check your connection and try again.",
+  },
+  {
+    name: "Music Mode",
+    url: "/ui/music-mode.html",
+    event: "getMusicModes",
+    emptyMessage: "This device doesn't support music modes.",
+    errorMessage:
+      "Couldn't load music modes. Check your connection and try again.",
+  },
+  {
+    name: "Toggle",
+    url: "/ui/toggle.html",
+    event: "getToggleFeatures",
+    emptyMessage: "This device has no toggleable features.",
+    errorMessage:
+      "Couldn't load toggleable features. Check your connection and try again.",
+  },
+];
+
+for (const { name, url, event, emptyMessage, errorMessage } of HINT_SCENARIOS) {
+  test.describe(`${name} field-hint behavior`, () => {
+    test.beforeEach(async ({ page }) => {
+      await installMockClient(page);
+      await page.goto(url);
+      // Wait for attachFieldStatus to have actually wired the hint
+      // element to the DOM (i.e. GoveePI.ready has fired and the PI's
+      // per-dropdown call completed). Before this point the handler
+      // isn't subscribed yet.
+      await page.waitForSelector(`[data-field-hint="${event}"]`, {
+        state: "attached",
+      });
+    });
+
+    test(`renders info hint when backend returns status="empty"`, async ({
+      page,
+    }) => {
+      await dispatchPIMessage(page, {
+        event,
+        status: "empty",
+        items: [],
+        message: emptyMessage,
+      });
+
+      const hint = page.locator(`[data-field-hint="${event}"]`);
+      await expect(hint).toBeAttached();
+      await expect(hint).toHaveText(emptyMessage);
+      await expect(hint).toHaveClass(/field-hint/);
+      await expect(hint).toHaveClass(/\binfo\b/);
+    });
+
+    test(`renders error hint when backend returns status="error"`, async ({
+      page,
+    }) => {
+      await dispatchPIMessage(page, {
+        event,
+        status: "error",
+        items: [],
+        message: errorMessage,
+      });
+
+      const hint = page.locator(`[data-field-hint="${event}"]`);
+      await expect(hint).toBeAttached();
+      await expect(hint).toHaveText(errorMessage);
+      await expect(hint).toHaveClass(/field-hint/);
+      await expect(hint).toHaveClass(/\berror\b/);
+    });
+
+    test(`clears hint when backend returns status="ok" with items`, async ({
+      page,
+    }) => {
+      // First send an empty status to render the hint.
+      await dispatchPIMessage(page, {
+        event,
+        status: "empty",
+        items: [],
+        message: emptyMessage,
+      });
+      const hint = page.locator(`[data-field-hint="${event}"]`);
+      await expect(hint).toHaveText(emptyMessage);
+
+      // Then send a populated ok response; the hint should be cleared.
+      await dispatchPIMessage(page, {
+        event,
+        status: "ok",
+        items: [{ label: "Option A", value: "a" }],
+      });
+      await expect(hint).toHaveClass(/\bhidden\b/);
+    });
+  });
+}


### PR DESCRIPTION
Prevents regressions of the bug classes Archie caught last week (#182 silent empty/error states, #184 broken Custom Effect dropdown) by adding both a typed compile-time contract and an end-to-end behavior test suite.

## Summary
- Introduce \`PIDatasourceResponse<E>\` + \`sendPIDatasource()\` typed helper. Makes \`status: "ok" | "empty" | "error"\` a compile-time required field on every datasource response.
- Migrate all six datasource handlers (\`handleGetDevices\`, Scene, Snapshot, MusicMode, Toggle, CustomEffect) to the typed helper. CustomEffect gains an explicit empty-state branch.
- E2E coverage: 33 → 101 tests. All 17 Property Inspectors now covered.

## New E2E files
- \`dependent-dropdowns.spec.ts\` — Scene, Snapshot, Music Mode, Toggle, Custom Effect. Asserts the datasource attribute wiring. **Would have caught #184's \`"effects"\` vs \`"getEffects"\` mismatch automatically.**
- \`feature-pis.spec.ts\` — Segment Color, Schedule, Sequence.
- \`field-hints.spec.ts\` — behavior test that mocks the SDPI client, dispatches synthetic backend responses with \`status=empty|error|ok\`, and asserts the \`.field-hint\` element renders with the correct class and text. **Regression of #182 would now fail in CI.**
- \`dial-actions.spec.ts\` — extended to Saturation Dial and Segment Color Dial.

## Test plan
- [x] \`npm run type-check\`
- [x] \`npm run lint\`
- [x] \`npm test\` — 491 unit tests pass
- [x] \`npx playwright test\` — 101 E2E tests pass (up from 33)
- [x] \`npm run build\`

## Notes
- Non-datasource \`sendToPI\` calls (groups, deviceDebug) remain on the untyped helper. Only datasource responses get the new contract — they're the class that caused silent-failure bugs.
- No behavior change for end users. This is purely guardrail work.