### PR TITLE
chore: add Hardware Dogfood section + weekly stale-review sweep

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -17,7 +17,7 @@ Skip this section ONLY for pure docs/CI/refactor PRs with zero runtime
 impact.
 -->
 
-**I tested the following specific flows on real hardware:**
+### I tested the following specific flows on real hardware
 
 <!-- Describe concrete actions, not generic checkmarks. e.g.:
   - Added Custom Effect action to button, selected 'Pulse' preset,
@@ -26,20 +26,23 @@ impact.
     saw "No snapshots found" hint instead of empty dropdown
 -->
 
+1.
+2.
+
+### Hardware / Stream Deck model tested
+
 -
-- **Hardware / Stream Deck model tested:**
 
-- **Stream Deck app version:**
+### Stream Deck app version
 
-- **If this touches a Property Inspector dropdown or datasource:**
+-
+
+### If this touches a Property Inspector dropdown or datasource
 
 - [ ] The dropdown populates when there are items
-- [ ] The dropdown shows a `.field-hint` when the backend returns
-      `status: "empty"` (no misleading "Select a device first")
-- [ ] The dropdown shows a `.field-hint` when the backend returns
-      `status: "error"`
-- [ ] I added/updated an E2E test in `test/e2e/` covering the new
-      wiring (see `dependent-dropdowns.spec.ts` for the pattern)
+- [ ] The dropdown shows a `.field-hint` when the backend returns `status: "empty"` (no misleading "Select a device first")
+- [ ] The dropdown shows a `.field-hint` when the backend returns `status: "error"`
+- [ ] I added/updated an E2E test in `test/e2e/` covering the new wiring (see `dependent-dropdowns.spec.ts` for the pattern)
 
 ## Type of Change
 
@@ -113,7 +116,7 @@ impact.
 - [ ] Error handling
 - [ ] API key validation
 - [ ] State management
-- [ ] Other: ******\_\_\_******
+- [ ] Other: **\*\***\_\_\_**\*\***
 
 ## Performance Impact
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,6 +5,42 @@
 <!--- Provide a general summary of your changes in the Title above -->
 <!--- Describe your changes in detail -->
 
+## 🎯 Hardware Dogfood (required for any behavior change)
+
+<!---
+Every behavior-changing PR must describe **end-to-end testing on real Govee
+hardware through the Stream Deck app** — not just "npm test passes". Unit
+tests caught zero of the bugs shipped in v2.1.4–v2.2.0; dogfooding catches
+first-click bugs that contributors otherwise have to find for us.
+
+Skip this section ONLY for pure docs/CI/refactor PRs with zero runtime
+impact.
+-->
+
+**I tested the following specific flows on real hardware:**
+
+<!-- Describe concrete actions, not generic checkmarks. e.g.:
+  - Added Custom Effect action to button, selected 'Pulse' preset,
+    pressed key — saw H6008 light pulse through red→blue→green
+  - Added Snapshot action with H60B0 (has no snapshots), opened PI —
+    saw "No snapshots found" hint instead of empty dropdown
+-->
+
+-
+- **Hardware / Stream Deck model tested:**
+
+- **Stream Deck app version:**
+
+- **If this touches a Property Inspector dropdown or datasource:**
+
+- [ ] The dropdown populates when there are items
+- [ ] The dropdown shows a `.field-hint` when the backend returns
+      `status: "empty"` (no misleading "Select a device first")
+- [ ] The dropdown shows a `.field-hint` when the backend returns
+      `status: "error"`
+- [ ] I added/updated an E2E test in `test/e2e/` covering the new
+      wiring (see `dependent-dropdowns.spec.ts` for the pattern)
+
 ## Type of Change
 
 <!--- Put an `x` in all the boxes that apply: -->
@@ -33,17 +69,17 @@
 <!--- Describe the changes you made in detail -->
 <!--- Use bullet points for clarity -->
 
-- 
-- 
-- 
+-
+-
+-
 
 ## Screenshots
 
 <!--- If your changes affect the UI, please provide screenshots -->
 <!--- Delete this section if not applicable -->
 
-| Before | After |
-|--------|--------|
+| Before         | After         |
+| -------------- | ------------- |
 | ![Before](url) | ![After](url) |
 
 ## Testing
@@ -53,10 +89,10 @@
 
 ### Test Environment
 
-- **OS**: 
-- **Stream Deck Version**: 
-- **Plugin Version**: 
-- **Node.js Version**: 
+- **OS**:
+- **Stream Deck Version**:
+- **Plugin Version**:
+- **Node.js Version**:
 
 ### Test Cases
 
@@ -77,7 +113,7 @@
 - [ ] Error handling
 - [ ] API key validation
 - [ ] State management
-- [ ] Other: _______________
+- [ ] Other: ******\_\_\_******
 
 ## Performance Impact
 

--- a/.github/workflows/stale-sweep.yml
+++ b/.github/workflows/stale-sweep.yml
@@ -1,0 +1,161 @@
+name: Stale Review Sweep
+
+# Weekly sweep that flags PRs and issues where the maintainer owes a response.
+# Prevents situations like #167 (12-day-silent reporter follow-up) and review
+# drift on contributor PRs. Posts a summary comment on the tracking issue
+# and labels stale items so they surface in the maintainer's view.
+
+on:
+  schedule:
+    # Every Monday at 09:00 UTC
+    - cron: "0 9 * * 1"
+  workflow_dispatch: # allow manual runs
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  sweep:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Flag stale PRs and issues awaiting maintainer response
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const STALE_DAYS = 7;
+            const now = Date.now();
+            const staleCutoff = now - STALE_DAYS * 24 * 60 * 60 * 1000;
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+
+            // Fetch open PRs
+            const prs = await github.paginate(github.rest.pulls.list, {
+              owner, repo, state: "open", per_page: 100,
+            });
+
+            // Fetch open issues (excluding PRs)
+            const issuesRaw = await github.paginate(github.rest.issues.listForRepo, {
+              owner, repo, state: "open", per_page: 100,
+            });
+            const issues = issuesRaw.filter(i => !i.pull_request);
+
+            const stalePrs = [];
+            const staleIssues = [];
+
+            // A PR is stale if:
+            //  - last activity > 7 days ago, AND
+            //  - the last commenter is NOT the maintainer, OR there are no
+            //    comments and the PR is older than 7 days.
+            for (const pr of prs) {
+              const comments = await github.paginate(github.rest.issues.listComments, {
+                owner, repo, issue_number: pr.number, per_page: 100,
+              });
+              const lastComment = comments[comments.length - 1];
+              const lastActivity = new Date(
+                lastComment?.created_at ?? pr.created_at
+              ).getTime();
+              if (lastActivity > staleCutoff) continue;
+
+              const lastAuthor = lastComment?.user?.login ?? pr.user?.login;
+              const isMaintainer = lastAuthor === owner;
+              if (!isMaintainer) {
+                stalePrs.push({
+                  number: pr.number,
+                  title: pr.title,
+                  author: pr.user?.login,
+                  daysStale: Math.floor((now - lastActivity) / (24 * 60 * 60 * 1000)),
+                  url: pr.html_url,
+                });
+              }
+            }
+
+            // An issue is stale if the reporter has posted after the last
+            // maintainer comment and no maintainer response has followed
+            // within 7 days. This surfaces unanswered follow-ups like #167.
+            for (const issue of issues) {
+              const comments = await github.paginate(github.rest.issues.listComments, {
+                owner, repo, issue_number: issue.number, per_page: 100,
+              });
+              if (comments.length === 0) {
+                const lastActivity = new Date(issue.created_at).getTime();
+                if (lastActivity < staleCutoff && issue.user?.login !== owner) {
+                  staleIssues.push({
+                    number: issue.number,
+                    title: issue.title,
+                    author: issue.user?.login,
+                    daysStale: Math.floor((now - lastActivity) / (24 * 60 * 60 * 1000)),
+                    url: issue.html_url,
+                  });
+                }
+                continue;
+              }
+              const lastComment = comments[comments.length - 1];
+              const lastActivity = new Date(lastComment.created_at).getTime();
+              if (lastActivity > staleCutoff) continue;
+              if (lastComment.user?.login === owner) continue;
+              staleIssues.push({
+                number: issue.number,
+                title: issue.title,
+                author: lastComment.user?.login,
+                daysStale: Math.floor((now - lastActivity) / (24 * 60 * 60 * 1000)),
+                url: issue.html_url,
+              });
+            }
+
+            // Build summary
+            const lines = [];
+            lines.push(`# Weekly Stale Review Sweep`);
+            lines.push(``);
+            lines.push(`Ran at ${new Date().toISOString()}.`);
+            lines.push(``);
+
+            if (stalePrs.length === 0 && staleIssues.length === 0) {
+              lines.push(`✅ Nothing stale. All PRs and issues have had a maintainer response in the last ${STALE_DAYS} days.`);
+            } else {
+              if (stalePrs.length > 0) {
+                lines.push(`## 🔔 PRs awaiting maintainer response (${stalePrs.length})`);
+                lines.push(``);
+                for (const p of stalePrs) {
+                  lines.push(`- [#${p.number}](${p.url}) by @${p.author} — last activity ${p.daysStale}d ago — ${p.title}`);
+                }
+                lines.push(``);
+              }
+              if (staleIssues.length > 0) {
+                lines.push(`## 🔔 Issues awaiting maintainer response (${staleIssues.length})`);
+                lines.push(``);
+                for (const i of staleIssues) {
+                  lines.push(`- [#${i.number}](${i.url}) — last comment by @${i.author} ${i.daysStale}d ago — ${i.title}`);
+                }
+                lines.push(``);
+              }
+            }
+
+            const body = lines.join("\n");
+            core.summary.addRaw(body).write();
+            console.log(body);
+
+            // If anything is stale, create or update a tracking issue so
+            // it surfaces in the maintainer's inbox, not just workflow logs.
+            if (stalePrs.length === 0 && staleIssues.length === 0) return;
+
+            const trackingTitle = "📋 Weekly Stale Review Sweep";
+            const existing = await github.paginate(
+              github.rest.issues.listForRepo,
+              { owner, repo, state: "open", creator: "github-actions[bot]", per_page: 100 }
+            );
+            const tracking = existing.find(i => i.title === trackingTitle);
+
+            if (tracking) {
+              await github.rest.issues.update({
+                owner, repo, issue_number: tracking.number, body,
+              });
+              await github.rest.issues.createComment({
+                owner, repo, issue_number: tracking.number,
+                body: `Sweep re-ran — see issue body for latest list.`,
+              });
+            } else {
+              await github.rest.issues.create({
+                owner, repo, title: trackingTitle, body,
+              });
+            }


### PR DESCRIPTION
Third and final leg of the quality-guardrail triad started in #185 (user-facing empty/error states) and #191 (compile-time + E2E guardrails). These are the social/process guardrails that catch what automation can't.

## Summary

**PR template (.github/pull_request_template.md)**
- Adds a prominent "🎯 Hardware Dogfood" section at the top asking contributors to describe concrete end-to-end testing on real Govee hardware — not just a generic "works" checkbox. Unit tests caught zero of the bugs that shipped in v2.1.4–v2.2.0.
- Adds a PI-specific sub-checklist (empty/error/populated dropdown states + E2E test addition) that would have prompted the Custom Effect dropdown bug from v2.2.0 to be caught pre-merge.
- Explicit skip clause for docs/CI/refactor PRs with zero runtime impact so low-risk changes don't face friction.

**Weekly stale-review sweep (.github/workflows/stale-sweep.yml)**
- Runs every Monday at 09:00 UTC + manual dispatch.
- Flags PRs where the maintainer owes a response for > 7 days.
- Flags issues where the reporter's last comment is unanswered for > 7 days — would have caught #167's 12-day-silent follow-up from @warlikcookie82 automatically.
- Creates (or updates) a single "📋 Weekly Stale Review Sweep" tracking issue so items surface in the maintainer's inbox, not just workflow logs.

## Test plan

- [x] YAML validates (\`js-yaml\` load)
- [ ] Manual: trigger \`workflow_dispatch\` after merge to confirm the sweep reports correctly
- [x] Template renders in GitHub preview after prettier formatting pass