### PR TITLE
fix: sequence step Device dropdown doesn't populate (#190)

### DIFF
--- a/com.felixgeelhaar.govee-light-management.sdPlugin/ui/sequence.html
+++ b/com.felixgeelhaar.govee-light-management.sdPlugin/ui/sequence.html
@@ -145,6 +145,7 @@
             <label>Light</label>
             <sdpi-select
               id="stepDevice"
+              setting="stepDeviceDraft"
               placeholder=""
               datasource="getDevices"
               show-refresh

--- a/test/e2e/sdpi-invariants.spec.ts
+++ b/test/e2e/sdpi-invariants.spec.ts
@@ -1,0 +1,50 @@
+/**
+ * Cross-PI invariants that should hold on every Property Inspector.
+ *
+ * Catches the class of bug in #190 where a `<sdpi-select>` had a
+ * `datasource` attribute but no `setting` attribute, which silently
+ * prevents the datasource subscription from firing. Users then see a
+ * non-populated dropdown that never responds.
+ */
+import { test, expect } from "@playwright/test";
+import { readdirSync } from "node:fs";
+import { join } from "node:path";
+
+const UI_DIR = join(
+  process.cwd(),
+  "com.felixgeelhaar.govee-light-management.sdPlugin",
+  "ui",
+);
+
+const HTML_FILES = readdirSync(UI_DIR)
+  .filter((f) => f.endsWith(".html"))
+  .sort();
+
+for (const file of HTML_FILES) {
+  test.describe(`${file} SDPI invariants`, () => {
+    test.beforeEach(async ({ page }) => {
+      await page.goto(`/ui/${file}`);
+    });
+
+    test("every sdpi-select with a datasource also has a setting", async ({
+      page,
+    }) => {
+      const offenders = await page.$$eval(
+        "sdpi-select[datasource]",
+        (nodes) =>
+          nodes
+            .filter((n) => !n.getAttribute("setting"))
+            .map((n) => ({
+              id: n.id || "(no id)",
+              datasource: n.getAttribute("datasource"),
+            })),
+      );
+      expect(
+        offenders,
+        `sdpi-select with datasource="..." but no setting attribute: ${JSON.stringify(
+          offenders,
+        )}. SDPI won't fire the datasource subscription without a setting.`,
+      ).toEqual([]);
+    });
+  });
+}


### PR DESCRIPTION
Closes #190.

## Root cause
The Sequence builder's Device dropdown in the step builder was declared as:

\`\`\`html
<sdpi-select id=\"stepDevice\" datasource=\"getDevices\" ...>
\`\`\`

No \`setting\` attribute. SDPI only fires its datasource subscription on components that have a setting binding, so the component rendered but never sent a \`getDevices\` event to the backend — the dropdown stayed empty and the user had no way to pick a device.

This regressed in #184 when the builder was migrated from a native \`<select>\` to \`<sdpi-select>\`.

## Fix
Add \`setting=\"stepDeviceDraft\"\` — a transient per-action setting. The step builder still reads the current value via \`stepDevice.value\` at Add-Step time, so runtime behavior is unchanged; the setting just gives SDPI the binding it needs to fire the datasource subscription.

## Regression guard
Added \`test/e2e/sdpi-invariants.spec.ts\` that loads every \`.html\` under \`ui/\` and asserts every \`sdpi-select[datasource]\` also has a \`setting\` attribute. 17 PIs now covered. Would have failed loudly on sequence.html before this fix.

## Test plan
- [x] \`npm run type-check\`
- [x] \`npm run build\`
- [x] \`npx playwright test\` — 101 + 17 new = 118 E2E tests pass
- [x] sdpi-invariants test passes for all 17 PIs