### PR TITLE
chore: release v2.3.1 — bump govee-api-client to 3.3.0

### DIFF
--- a/com.felixgeelhaar.govee-light-management.sdPlugin/manifest.json
+++ b/com.felixgeelhaar.govee-light-management.sdPlugin/manifest.json
@@ -1,6 +1,6 @@
 {
   "Name": "Govee Light Management",
-  "Version": "2.3.0.0",
+  "Version": "2.3.1.0",
   "Author": "Felix Geelhaar",
   "URL": "https://github.com/felixgeelhaar/govee-light-management",
   "SupportURL": "https://github.com/felixgeelhaar/govee-light-management/issues",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "govee-light-management",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "govee-light-management",
-      "version": "2.3.0",
+      "version": "2.3.1",
       "license": "MIT",
       "dependencies": {
         "@elgato/streamdeck": "^2.0.4",
-        "@felixgeelhaar/govee-api-client": "^3.2.0",
+        "@felixgeelhaar/govee-api-client": "^3.3.0",
         "zod": "4.3.5"
       },
       "devDependencies": {
@@ -577,9 +577,9 @@
       }
     },
     "node_modules/@felixgeelhaar/govee-api-client": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@felixgeelhaar/govee-api-client/-/govee-api-client-3.2.0.tgz",
-      "integrity": "sha512-nJr4zjJ1S1y5ZMnNY9+s/s5GtpVK+Vdxco+YajoJdx2ovXZC2zjYJbGkODbt79V7/8VnKEixp9grWxhRhqwv/A==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@felixgeelhaar/govee-api-client/-/govee-api-client-3.3.0.tgz",
+      "integrity": "sha512-aNhNZmC/Se1O/kpKyXXEtjRtLijf5zba2IB2TtJqzPdTa2oStZVqgyu4i9sugEXkQmRYI/K1xOHbMZz2kuB3Mg==",
       "license": "MIT",
       "dependencies": {
         "axios": "1.15.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "govee-light-management",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "Enterprise-grade Stream Deck plugin for managing Govee lights with advanced group functionality",
   "main": "com.felixgeelhaar.govee-light-management.sdPlugin/bin/plugin.js",
   "scripts": {
@@ -61,7 +61,7 @@
   },
   "dependencies": {
     "@elgato/streamdeck": "^2.0.4",
-    "@felixgeelhaar/govee-api-client": "^3.2.0",
+    "@felixgeelhaar/govee-api-client": "^3.3.0",
     "zod": "4.3.5"
   },
   "overrides": {


### PR DESCRIPTION
Patches v2.3.0's broken DIY scene support by bumping the govee-api-client dependency from 3.2.0 → 3.3.0 (released today).

## Why this is urgent
v2.3.0 advertised DIY scene support via the Scene action merge (PR #181), but the installed client 3.2.0 fetched DIY scenes from \`/router/api/v1/device/scenes\` — the wrong endpoint. That endpoint never returns DIY options, so DIY scene dropdowns silently returned empty for essentially every device. Users who tried the feature saw nothing.

## What the client bump fixes
- DIY scene discovery now hits the dedicated \`/router/api/v1/device/diy-scenes\` endpoint
- DIY scene commands serialize the numeric ID Govee actually expects (was an object payload)
- Mixed-shape scene values in a single response no longer invalidate the whole payload
- Snapshot discovery falls back to \`/user/devices\` capability metadata when \`/device/scenes\` returns no snapshot entries (fixes H61E5-class devices)
- \`DeviceState.online\` reflects the real \`devices.capabilities.online\` state instead of being hardcoded to true

See [govee-api-client v3.3.0 CHANGELOG](https://github.com/felixgeelhaar/govee-api-client/blob/main/CHANGELOG.md#330---2026-04-18) for full details.

## Test plan
- [x] \`npm run type-check\`
- [x] \`npm run lint\`
- [x] \`npm test\` — 492 unit tests pass
- [x] \`npx playwright test\` — 118 E2E tests pass
- [x] \`npm run build\`
- [x] \`npx streamdeck validate\` — plugin validation passes
- [x] Confirmed installed client has the new endpoint + online parser via \`grep\` in node_modules