### PR TITLE
chore: broaden release notes grep + refresh store listing to v2.3.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,8 +53,22 @@ jobs:
             echo "## What's New in v${{ steps.version.outputs.VERSION }}"
             echo ""
             if [ -n "$PREV_TAG" ]; then
+              # Include every conventional-commit type so chore-only releases
+              # (e.g. dep bumps, release bumps) and docs updates still show up.
+              # Previously the filter only matched feat/fix/perf/refactor,
+              # leaving v2.3.1's "What's New" empty after a dep bump.
               git log ${PREV_TAG}..HEAD --pretty=format:"- %s" \
-                --grep="^feat" --grep="^fix" --grep="^perf" --grep="^refactor"
+                --grep="^feat" \
+                --grep="^fix" \
+                --grep="^perf" \
+                --grep="^refactor" \
+                --grep="^chore" \
+                --grep="^docs" \
+                --grep="^build" \
+                --grep="^ci" \
+                --grep="^test" \
+                --grep="^style" \
+                --grep="^revert"
               echo ""
             fi
             echo ""

--- a/docs/STORE_LISTING.md
+++ b/docs/STORE_LISTING.md
@@ -1,6 +1,6 @@
-# Elgato Marketplace Store Listing — v2.2.0
+# Elgato Marketplace Store Listing — v2.3.1
 
-Use this content when submitting v2.2.0 to the Elgato Maker Console.
+Use this content when submitting v2.3.1 to the Elgato Maker Console.
 
 ---
 
@@ -61,6 +61,45 @@ The API key is entered once and shared across all actions. No accounts, no serve
 Works with all Govee lights that support the Govee Developer API, including LED strips, bulbs, light bars, floor lamps, and RGB IC strip lights. Supports Stream Deck, Stream Deck MK.2, Stream Deck XL, Stream Deck Mini, Stream Deck Neo, Stream Deck Pedal, and Stream Deck+.
 
 ---
+
+## What's New / Release Notes (v2.3.1)
+
+**Feature delivery + reliability fixes that finish what v2.3.0 started**
+
+### Fixed in v2.3.1
+
+- **DIY scenes actually populate now.** v2.3.0 advertised DIY scene support, but the underlying API client was querying the wrong Govee endpoint. Dropdowns silently returned empty. Bumping the client library fixes it — DIY scenes fetched directly from Govee's dedicated endpoint, matching how the Govee mobile app sees them.
+- **Snapshots load for more device models.** Devices like the H61E5 expose their snapshot presets through a different API path than standard lights. The client now falls back to that path when the primary one returns empty.
+- **Accurate offline detection.** Device online state is read from the actual Govee capability instead of being optimistically assumed. When a light is unreachable, the plugin knows — no more silent command failures.
+
+## What's New / Release Notes (v2.3.0)
+
+**DIY scenes, device metadata panel, and a quality-guardrail overhaul**
+
+### New Features
+
+- **DIY Scenes in the Scene action** — Your custom scenes created in the Govee mobile app now appear alongside the built-in dynamic scenes, all in one dropdown. Labeled with `(DIY)` so you can tell them apart at a glance.
+- **Device Metadata Panel in Property Inspectors** — A new debug section shows the selected device's ID, model, capabilities, and supported commands in a clean structured layout. Click to copy IDs when you need them for troubleshooting.
+
+### Fixed
+
+- **Property Inspector dropdowns now explain themselves.** When a device has no scenes, no snapshots, no music modes, or no toggleable features, the dropdown shows a clear message instead of the misleading "Select a device first" placeholder. Backend errors (bad API key, network failure) show a distinct error hint. Covers Scene, Snapshot, Music Mode, Toggle, Device, and the Custom Effect dropdown.
+- **Custom Effect dropdown now loads its presets.** A datasource wiring mismatch shipped in v2.2.0 prevented the effect list from populating — Custom Effect was essentially unusable. Fixed.
+- **Sequence step Device dropdown populates.** The step builder's Device dropdown was missing the binding SDPI needs to fire its datasource subscription, so it rendered empty with no way to pick a device.
+- **Govee cloud pseudo-groups filtered out.** Entries like `BaseGroup`, `SameModelGroup`, and `SameModeGroup` are not controllable through the public API — they used to appear as selectable lights that silently failed every command. Now they're filtered during discovery and a clear error hint is shown if a stale selection points at one.
+- **Snapshot & Music Mode dropdowns for capability-driven devices.** Devices that expose their options through nested capability fields (not simple datasource enumeration) now populate correctly.
+
+### Sequence Builder Polish
+
+- Delay steps now use **seconds** instead of milliseconds for readability
+- Step list shows friendly device names and command labels instead of raw IDs
+- Properly styled dropdowns matching the rest of the plugin
+
+### Under the Hood
+
+- Typed `sendPIDatasource` contract makes it a compile-time error to ship a PI datasource response without `status: "ok" | "empty" | "error"` — the bug class behind the v2.2.0 regressions can't silently recur
+- E2E test suite expanded from 33 to 118 tests across all 17 Property Inspectors
+- PR template now requires concrete hardware-dogfood descriptions; weekly stale-review workflow surfaces unanswered issues
 
 ## What's New / Release Notes (v2.2.0)
 


### PR DESCRIPTION
Closes two post-release retro gaps found after v2.3.1 shipped.

## Why
1. **Empty release notes.** v2.3.1's GitHub release had an empty \"What's New\" section because its only commit used the \`chore:\` prefix, and \`release.yml\`'s notes generator grep-filtered to \`feat|fix|perf|refactor\`. I edited the v2.3.1 release body manually to cover the DIY/online/snapshot-fallback fixes, but the workflow itself would silently drop future chore-only or docs-only releases the same way.
2. **Marketplace store listing was stale at v2.2.0.** \`docs/STORE_LISTING.md\` didn't reflect any v2.3.x work — no DIY scenes callout, no device metadata panel, no PI empty/error state messaging, no Custom Effect fix, no cloud pseudo-group filtering. Resubmission would have gone out with stale copy.

## Changes
- **.github/workflows/release.yml**: broaden the \`git log --grep\` in the release-notes step to cover every conventional commit type (\`feat\`/\`fix\`/\`perf\`/\`refactor\`/\`chore\`/\`docs\`/\`build\`/\`ci\`/\`test\`/\`style\`/\`revert\`). Chore-only releases will now produce useful changelogs.
- **docs/STORE_LISTING.md**: header updated to v2.3.1, added v2.3.0 + v2.3.1 release-note sections preserving the v2.2.0 / v2.1.x history beneath them.

## Test plan
- [x] \`npm run lint\` / \`type-check\` (unaffected by either change)
- [x] YAML validates (\`js-yaml\` load)
- [ ] Verify on next tagged release that chore commits appear in the auto-generated notes (will happen naturally on v2.3.2+)