### PR TITLE
fix: dreamViewToggle live state + release v2.3.2

### DIFF
--- a/com.felixgeelhaar.govee-light-management.sdPlugin/manifest.json
+++ b/com.felixgeelhaar.govee-light-management.sdPlugin/manifest.json
@@ -1,6 +1,6 @@
 {
   "Name": "Govee Light Management",
-  "Version": "2.3.1.0",
+  "Version": "2.3.2.0",
   "Author": "Felix Geelhaar",
   "URL": "https://github.com/felixgeelhaar/govee-light-management",
   "SupportURL": "https://github.com/felixgeelhaar/govee-light-management/issues",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@elgato/streamdeck": "^2.0.4",
-        "@felixgeelhaar/govee-api-client": "^3.3.0",
+        "@felixgeelhaar/govee-api-client": "^3.3.1",
         "zod": "4.3.5"
       },
       "devDependencies": {
@@ -577,9 +577,9 @@
       }
     },
     "node_modules/@felixgeelhaar/govee-api-client": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@felixgeelhaar/govee-api-client/-/govee-api-client-3.3.0.tgz",
-      "integrity": "sha512-aNhNZmC/Se1O/kpKyXXEtjRtLijf5zba2IB2TtJqzPdTa2oStZVqgyu4i9sugEXkQmRYI/K1xOHbMZz2kuB3Mg==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@felixgeelhaar/govee-api-client/-/govee-api-client-3.3.1.tgz",
+      "integrity": "sha512-QGraEvyQVx+64X3vK1Z+Qu2lV8ez9vHrRqPE6dRS0Hb/qGOBZJHwSVX8BTYIzyH8WGA50+AMqy0yacCxFUyTZA==",
       "license": "MIT",
       "dependencies": {
         "axios": "1.15.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "govee-light-management",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "description": "Enterprise-grade Stream Deck plugin for managing Govee lights with advanced group functionality",
   "main": "com.felixgeelhaar.govee-light-management.sdPlugin/bin/plugin.js",
   "scripts": {
@@ -61,7 +61,7 @@
   },
   "dependencies": {
     "@elgato/streamdeck": "^2.0.4",
-    "@felixgeelhaar/govee-api-client": "^3.3.0",
+    "@felixgeelhaar/govee-api-client": "^3.3.1",
     "zod": "4.3.5"
   },
   "overrides": {

--- a/src/backend/infrastructure/repositories/GoveeLightRepository.ts
+++ b/src/backend/infrastructure/repositories/GoveeLightRepository.ts
@@ -818,19 +818,12 @@ export class GoveeLightRepository implements ILightRepository {
         light.model,
       );
 
-      switch (instance) {
-        case "nightlightToggle":
-          return deviceState.getNightlightToggle() ?? false;
-        case "gradientToggle":
-          return deviceState.getGradientToggle() ?? false;
-        case "sceneStageToggle":
-          return deviceState.getSceneStageToggle() ?? false;
-        default:
-          streamDeck.logger.warn(
-            `No live toggle-state reader for ${instance} on ${light.name}`,
-          );
-          return undefined;
-      }
+      // govee-api-client 3.3.1+ exposes every toggle-capability instance
+      // via DeviceState.getToggle(instance), including dreamViewToggle
+      // and any new instance Govee adds. Returns undefined when the
+      // device did not report that instance, which the caller (Toggle
+      // action) handles as "no live state, fall back to cached".
+      return deviceState.getToggle(instance);
     } catch (error) {
       if (isValidationError(error)) {
         streamDeck.logger.warn(


### PR DESCRIPTION
Closes the toggle-state audit gap found during the v2.3.1 retro.

## Problem
\`GoveeLightRepository.getToggleState\` switched on the instance name with cases only for \`nightlightToggle\`, \`gradientToggle\`, \`sceneStageToggle\`. The \`default\` branch logged a warning and returned \`undefined\`. Users who bound a Toggle action to **DreamView** (available on RGB IC strips) could send on/off commands fine, but the Stream Deck button title's state indicator (\`●\`/\`○\`) always fell back to the cached default — live state was never queried correctly.

This is in the state-read path, not the datasource-emit path, so none of the v2.3.0 guardrails (\`sendPIDatasource\` typed contract, field-hint E2E tests, \`sdpi-invariants\`) caught it.

## Fix
govee-api-client 3.3.1 (released today) added a generic \`DeviceState.getToggle(instance)\` that reads any toggle capability — \`dreamViewToggle\`, future Govee additions — by instance name. Replaces the switch with a single call. Future toggle instances work with zero plugin changes.

Bumps:
- \`@felixgeelhaar/govee-api-client\`: \`^3.3.0\` → \`^3.3.1\`
- Plugin version: 2.3.1 → 2.3.2
- Manifest: 2.3.1.0 → 2.3.2.0

## Test plan
- [x] \`npm run type-check\` / \`lint\`
- [x] \`npm test\` — 492 unit tests pass
- [x] \`npx playwright test\` — 118 E2E tests pass
- [x] \`npm run build\` + \`npx streamdeck validate\` pass
- [x] Verified new client version installed in node_modules; \`getToggle\` helper present