### PR TITLE
feat: Sequence step scene + snapshot groundwork (#199)

### DIFF
--- a/src/backend/domain/value-objects/SequenceStep.ts
+++ b/src/backend/domain/value-objects/SequenceStep.ts
@@ -11,13 +11,32 @@ export type StepCommand =
   | "toggle"
   | "brightness"
   | "color"
-  | "colorTemperature";
+  | "colorTemperature"
+  | "scene"
+  | "snapshot";
+
+/** Structured payload for a scene step (dynamic or user-created DIY). */
+export interface ScenePayload {
+  kind: "dynamic" | "diy";
+  id: number;
+  paramId: number;
+  name: string;
+}
+
+/** Structured payload for a snapshot step. */
+export interface SnapshotPayload {
+  id: number;
+  paramId: number;
+  name: string;
+}
 
 export interface ActionStepProps {
   targetId: string;
   targetType: StepTarget;
   command: StepCommand;
   commandValue?: number | string;
+  scenePayload?: ScenePayload;
+  snapshotPayload?: SnapshotPayload;
 }
 
 export interface SequenceStepJSON {
@@ -26,12 +45,24 @@ export interface SequenceStepJSON {
   targetType?: StepTarget;
   command?: StepCommand;
   commandValue?: number | string;
+  scenePayload?: ScenePayload;
+  snapshotPayload?: SnapshotPayload;
   durationMs?: number;
 }
 
 /**
  * Immutable sequence step value object.
  * Represents either a light action or a timing delay.
+ *
+ * Supported action commands:
+ *  - Power: "on", "off", "toggle"
+ *  - Scalar-valued: "brightness" (0-100), "color" (hex string),
+ *    "colorTemperature" (kelvin number)
+ *  - Structured: "scene" (uses scenePayload), "snapshot" (uses snapshotPayload)
+ *
+ * The structured payload shape is used for commands whose domain value
+ * doesn't fit a simple scalar. Older JSON blobs without these fields
+ * continue to deserialize cleanly since they always use `commandValue`.
  */
 export class SequenceStep {
   private constructor(
@@ -41,6 +72,8 @@ export class SequenceStep {
       targetType?: StepTarget;
       command?: StepCommand;
       commandValue?: number | string;
+      scenePayload?: ScenePayload;
+      snapshotPayload?: SnapshotPayload;
       durationMs?: number;
     },
   ) {}
@@ -51,11 +84,54 @@ export class SequenceStep {
     if (!props.targetId || props.targetId.trim() === "") {
       throw new Error("Target ID cannot be empty");
     }
+    if (props.command === "scene" && !props.scenePayload) {
+      throw new Error("Scene step requires scenePayload");
+    }
+    if (props.command === "snapshot" && !props.snapshotPayload) {
+      throw new Error("Snapshot step requires snapshotPayload");
+    }
     return new SequenceStep(StepType.Action, {
       targetId: props.targetId,
       targetType: props.targetType,
       command: props.command,
       commandValue: props.commandValue,
+      scenePayload: props.scenePayload,
+      snapshotPayload: props.snapshotPayload,
+    });
+  }
+
+  static scene(
+    targetId: string,
+    targetType: StepTarget,
+    payload: ScenePayload,
+  ): SequenceStep {
+    if (!["dynamic", "diy"].includes(payload.kind)) {
+      throw new Error(`Invalid scene kind: ${payload.kind}`);
+    }
+    if (!Number.isInteger(payload.id) || payload.id <= 0) {
+      throw new Error(`Invalid scene id: ${payload.id}`);
+    }
+    return SequenceStep.action({
+      targetId,
+      targetType,
+      command: "scene",
+      scenePayload: payload,
+    });
+  }
+
+  static snapshot(
+    targetId: string,
+    targetType: StepTarget,
+    payload: SnapshotPayload,
+  ): SequenceStep {
+    if (!Number.isInteger(payload.id) || payload.id <= 0) {
+      throw new Error(`Invalid snapshot id: ${payload.id}`);
+    }
+    return SequenceStep.action({
+      targetId,
+      targetType,
+      command: "snapshot",
+      snapshotPayload: payload,
     });
   }
 
@@ -87,6 +163,14 @@ export class SequenceStep {
     return this.data.commandValue;
   }
 
+  get scenePayload(): ScenePayload | undefined {
+    return this.data.scenePayload;
+  }
+
+  get snapshotPayload(): SnapshotPayload | undefined {
+    return this.data.snapshotPayload;
+  }
+
   // ─── Delay Step Properties ───────────────────────────────
 
   get durationMs(): number | undefined {
@@ -102,6 +186,8 @@ export class SequenceStep {
       targetType: this.data.targetType,
       command: this.data.command,
       commandValue: this.data.commandValue,
+      scenePayload: this.data.scenePayload,
+      snapshotPayload: this.data.snapshotPayload,
       durationMs: this.data.durationMs,
     };
   }
@@ -113,6 +199,8 @@ export class SequenceStep {
         targetType: json.targetType!,
         command: json.command!,
         commandValue: json.commandValue,
+        scenePayload: json.scenePayload,
+        snapshotPayload: json.snapshotPayload,
       });
     }
     return SequenceStep.delay(json.durationMs!);

--- a/src/backend/services/SequenceService.ts
+++ b/src/backend/services/SequenceService.ts
@@ -3,6 +3,9 @@ import {
   Brightness,
   ColorRgb,
   ColorTemperature,
+  DiyScene,
+  LightScene,
+  Snapshot,
 } from "@felixgeelhaar/govee-api-client";
 import { Sequence } from "../domain/entities/Sequence";
 import { SequenceStep, StepType } from "../domain/value-objects/SequenceStep";
@@ -83,6 +86,59 @@ class SequenceServiceImpl {
       step.command === "colorTemperature"
     ) {
       await this.actionServices.controlTarget(target, step.command, value);
+      return;
+    }
+
+    if (step.command === "scene" && step.scenePayload) {
+      const payload = step.scenePayload;
+      const lights =
+        target.type === "light" && target.light
+          ? [target.light]
+          : (target.group?.getControllableLights() ?? []);
+      for (const light of lights) {
+        try {
+          if (payload.kind === "diy") {
+            const scene = new DiyScene(
+              payload.id,
+              payload.paramId,
+              payload.name,
+            );
+            await this.actionServices.applyDiyScene(light, scene);
+          } else {
+            const scene = new LightScene(
+              payload.id,
+              payload.paramId,
+              payload.name,
+            );
+            await this.actionServices.applyDynamicScene(light, scene);
+          }
+        } catch (error) {
+          streamDeck.logger?.warn(
+            `Sequence scene step failed for ${light.name}:`,
+            error,
+          );
+        }
+      }
+      return;
+    }
+
+    if (step.command === "snapshot" && step.snapshotPayload) {
+      const payload = step.snapshotPayload;
+      const snapshot = new Snapshot(payload.id, payload.paramId, payload.name);
+      const lights =
+        target.type === "light" && target.light
+          ? [target.light]
+          : (target.group?.getControllableLights() ?? []);
+      for (const light of lights) {
+        try {
+          await this.actionServices.applySnapshot(light, snapshot);
+        } catch (error) {
+          streamDeck.logger?.warn(
+            `Sequence snapshot step failed for ${light.name}:`,
+            error,
+          );
+        }
+      }
     }
   }
 

--- a/test/domain/value-objects/SequenceStep.test.ts
+++ b/test/domain/value-objects/SequenceStep.test.ts
@@ -119,4 +119,149 @@ describe("SequenceStep", () => {
       expect(restored.durationMs).toBe(original.durationMs);
     });
   });
+
+  describe("Scene Step (#199 groundwork)", () => {
+    it("creates a dynamic scene step with its payload", () => {
+      const step = SequenceStep.scene("light:dev|H6159", "light", {
+        kind: "dynamic",
+        id: 3853,
+        paramId: 4280,
+        name: "Sunrise",
+      });
+      expect(step.type).toBe(StepType.Action);
+      expect(step.command).toBe("scene");
+      expect(step.scenePayload?.kind).toBe("dynamic");
+      expect(step.scenePayload?.id).toBe(3853);
+      expect(step.scenePayload?.name).toBe("Sunrise");
+    });
+
+    it("creates a DIY scene step distinctly from dynamic", () => {
+      const step = SequenceStep.scene("light:dev|H6159", "light", {
+        kind: "diy",
+        id: 7001,
+        paramId: 7001,
+        name: "My Custom Glow",
+      });
+      expect(step.scenePayload?.kind).toBe("diy");
+    });
+
+    it("rejects unknown scene kind", () => {
+      expect(() =>
+        SequenceStep.scene("light:dev|H6159", "light", {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          kind: "bogus" as any,
+          id: 1,
+          paramId: 1,
+          name: "x",
+        }),
+      ).toThrow(/Invalid scene kind/);
+    });
+
+    it("rejects non-positive scene id", () => {
+      expect(() =>
+        SequenceStep.scene("light:dev|H6159", "light", {
+          kind: "dynamic",
+          id: 0,
+          paramId: 1,
+          name: "x",
+        }),
+      ).toThrow(/Invalid scene id/);
+    });
+
+    it("direct action(command:'scene') without payload throws", () => {
+      expect(() =>
+        SequenceStep.action({
+          targetId: "light:dev|H6159",
+          targetType: "light",
+          command: "scene",
+        }),
+      ).toThrow(/Scene step requires scenePayload/);
+    });
+
+    it("round-trips scene step via JSON preserving payload", () => {
+      const original = SequenceStep.scene("group:g1", "group", {
+        kind: "diy",
+        id: 12345,
+        paramId: 67890,
+        name: "Sparkles",
+      });
+      const restored = SequenceStep.fromJSON(original.toJSON());
+      expect(restored.command).toBe("scene");
+      expect(restored.targetType).toBe("group");
+      expect(restored.scenePayload).toEqual({
+        kind: "diy",
+        id: 12345,
+        paramId: 67890,
+        name: "Sparkles",
+      });
+    });
+  });
+
+  describe("Snapshot Step (#199 groundwork)", () => {
+    it("creates a snapshot step with its payload", () => {
+      const step = SequenceStep.snapshot("light:dev|H60B0", "light", {
+        id: 501,
+        paramId: 502,
+        name: "Reading",
+      });
+      expect(step.type).toBe(StepType.Action);
+      expect(step.command).toBe("snapshot");
+      expect(step.snapshotPayload?.id).toBe(501);
+      expect(step.snapshotPayload?.name).toBe("Reading");
+    });
+
+    it("rejects non-positive snapshot id", () => {
+      expect(() =>
+        SequenceStep.snapshot("light:dev|H60B0", "light", {
+          id: 0,
+          paramId: 1,
+          name: "x",
+        }),
+      ).toThrow(/Invalid snapshot id/);
+    });
+
+    it("direct action(command:'snapshot') without payload throws", () => {
+      expect(() =>
+        SequenceStep.action({
+          targetId: "light:dev|H60B0",
+          targetType: "light",
+          command: "snapshot",
+        }),
+      ).toThrow(/Snapshot step requires snapshotPayload/);
+    });
+
+    it("round-trips snapshot step via JSON preserving payload", () => {
+      const original = SequenceStep.snapshot("light:dev|H60B0", "light", {
+        id: 501,
+        paramId: 502,
+        name: "Movie Night",
+      });
+      const restored = SequenceStep.fromJSON(original.toJSON());
+      expect(restored.command).toBe("snapshot");
+      expect(restored.snapshotPayload).toEqual({
+        id: 501,
+        paramId: 502,
+        name: "Movie Night",
+      });
+    });
+  });
+
+  describe("Backwards-compat: legacy JSON (no new fields) still deserializes", () => {
+    it("action step without scenePayload/snapshotPayload fields loads cleanly", () => {
+      // Persisted settings from pre-#199 versions never had these fields.
+      // fromJSON must not require them for non-scene/non-snapshot commands.
+      const legacy = {
+        type: StepType.Action,
+        targetId: "light:dev|H6159",
+        targetType: "light" as const,
+        command: "brightness" as const,
+        commandValue: 50,
+      };
+      const step = SequenceStep.fromJSON(legacy);
+      expect(step.command).toBe("brightness");
+      expect(step.commandValue).toBe(50);
+      expect(step.scenePayload).toBeUndefined();
+      expect(step.snapshotPayload).toBeUndefined();
+    });
+  });
 });


### PR DESCRIPTION
**Draft — tracking issue #199. Not for user-visible release until the v2.5.0 Sequence builder UI work is ready.**

Non-breaking domain / service scaffolding. Adds \`scene\` and \`snapshot\` as first-class SequenceStep commands so a future UI pass only needs to touch the Property Inspector; the domain value-object and execution dispatch are done.

## Scope
Minimal, high-leverage subset of #199's full wishlist:
- ✅ \`scene\` step (dynamic + DIY)
- ✅ \`snapshot\` step
- 🚫 \`musicMode\`, \`toggleFeature\`, \`segmentColor\` — deferred; same pattern when implemented later

\`color\` and \`colorTemperature\` were already in the \`StepCommand\` union (wired in \`SequenceService.executeStep\`); they just don't have a builder UI yet.

## Changes
- \`SequenceStep\` extends \`StepCommand\` with \`"scene"\` and \`"snapshot"\`
- New \`ScenePayload\` / \`SnapshotPayload\` interfaces and optional fields on \`ActionStepProps\` / \`SequenceStepJSON\`
- Dedicated \`SequenceStep.scene(...)\` and \`SequenceStep.snapshot(...)\` factories with validation (kind whitelist, positive integer IDs)
- \`SequenceService.executeStep\` dispatches scene steps to \`applyDynamicScene\` or \`applyDiyScene\` based on \`payload.kind\`, and snapshot steps to \`applySnapshot\`. Both iterate group members with per-member error logging (consistent with the dedicated Scene/Snapshot actions)
- 11 new tests covering factory validation, JSON round-trip preservation of payloads, and explicit backwards-compat (legacy JSON without new fields deserializes cleanly)

## Non-breaking
- Existing sequences and step types behave identically
- Persisted JSON from pre-#199 versions loads without issue (no new required fields)
- UI unchanged — users can't create scene/snapshot steps through the PI until the v2.5.0 builder extension lands

## Test plan
- [x] \`npm run type-check\` / \`lint\`
- [x] \`npm test\` — 503 pass (was 492)
- [x] \`npx playwright test\` — 118 pass
- [x] \`npm run build\`

## Why draft
Shipping only the domain/service layer without the UI consumer would add dead code to a release. Unlocking this in user-visible form belongs in v2.5.0 alongside the builder UI extension. Keeping this as a merged-main branch (not yet in a release) so the work is on the trunk, discoverable, and ready for the UI pass. Or we hold it as a draft PR until the UI pass — your call.

Related: #199 tracks the full wishlist; this PR knocks out 2/7 step types at the domain layer.