### PR TITLE
chore: release v2.4.1 — snapshot button fix (#198)

### DIFF
--- a/com.felixgeelhaar.govee-light-management.sdPlugin/manifest.json
+++ b/com.felixgeelhaar.govee-light-management.sdPlugin/manifest.json
@@ -1,6 +1,6 @@
 {
   "Name": "Govee Light Management",
-  "Version": "2.4.0.0",
+  "Version": "2.4.1.0",
   "Author": "Felix Geelhaar",
   "URL": "https://github.com/felixgeelhaar/govee-light-management",
   "SupportURL": "https://github.com/felixgeelhaar/govee-light-management/issues",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@elgato/streamdeck": "^2.0.4",
-        "@felixgeelhaar/govee-api-client": "^3.3.1",
+        "@felixgeelhaar/govee-api-client": "^3.3.2",
         "zod": "4.3.5"
       },
       "devDependencies": {
@@ -577,9 +577,9 @@
       }
     },
     "node_modules/@felixgeelhaar/govee-api-client": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@felixgeelhaar/govee-api-client/-/govee-api-client-3.3.1.tgz",
-      "integrity": "sha512-QGraEvyQVx+64X3vK1Z+Qu2lV8ez9vHrRqPE6dRS0Hb/qGOBZJHwSVX8BTYIzyH8WGA50+AMqy0yacCxFUyTZA==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/@felixgeelhaar/govee-api-client/-/govee-api-client-3.3.2.tgz",
+      "integrity": "sha512-BoTDI46qV3E84XNn1oxyuu0fhQO2aUmknp5emZBW6SY++b2/hN1BkwOed76zP5Ba5ktHXCPBSzMlHCEvggjWDw==",
       "license": "MIT",
       "dependencies": {
         "axios": "1.15.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "govee-light-management",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "description": "Enterprise-grade Stream Deck plugin for managing Govee lights with advanced group functionality",
   "main": "com.felixgeelhaar.govee-light-management.sdPlugin/bin/plugin.js",
   "scripts": {
@@ -61,7 +61,7 @@
   },
   "dependencies": {
     "@elgato/streamdeck": "^2.0.4",
-    "@felixgeelhaar/govee-api-client": "^3.3.1",
+    "@felixgeelhaar/govee-api-client": "^3.3.2",
     "zod": "4.3.5"
   },
   "overrides": {


### PR DESCRIPTION
Closes #198. Bumps `@felixgeelhaar/govee-api-client` to 3.3.2 (released today, includes the numeric-ID snapshot control payload). v2.4.0 remains the marketplace submission; this is a GitHub patch so affected users can grab the fix immediately.

## Test plan
- [x] type-check, lint, build, `streamdeck validate`
- [x] 492 unit + 118 E2E pass
- [x] Installed client v3.3.2 verified in node_modules