### PR TITLE
feat: number input alongside sliders + release v2.4.2 (#200)

### DIFF
--- a/com.felixgeelhaar.govee-light-management.sdPlugin/manifest.json
+++ b/com.felixgeelhaar.govee-light-management.sdPlugin/manifest.json
@@ -1,6 +1,6 @@
 {
   "Name": "Govee Light Management",
-  "Version": "2.4.1.0",
+  "Version": "2.4.2.0",
   "Author": "Felix Geelhaar",
   "URL": "https://github.com/felixgeelhaar/govee-light-management",
   "SupportURL": "https://github.com/felixgeelhaar/govee-light-management/issues",

--- a/com.felixgeelhaar.govee-light-management.sdPlugin/ui/brightness.html
+++ b/com.felixgeelhaar.govee-light-management.sdPlugin/ui/brightness.html
@@ -29,6 +29,7 @@
           step="1"
           showlabels
           data-suffix="%"
+          data-number-input
         >
           <span slot="min">Off</span>
           <span slot="max">Max</span>

--- a/com.felixgeelhaar.govee-light-management.sdPlugin/ui/color-temperature.html
+++ b/com.felixgeelhaar.govee-light-management.sdPlugin/ui/color-temperature.html
@@ -29,6 +29,7 @@
           step="1"
           showlabels
           data-suffix="%"
+          data-number-input
         >
           <span slot="min">Warm</span>
           <span slot="max">Cool</span>

--- a/com.felixgeelhaar.govee-light-management.sdPlugin/ui/css/main.css
+++ b/com.felixgeelhaar.govee-light-management.sdPlugin/ui/css/main.css
@@ -233,3 +233,45 @@
 .field-hint.error {
 	color: #ff6b6b;
 }
+
+/* Slider paired with a direct-entry number input (#200). */
+.range-with-number {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	width: 100%;
+}
+
+.range-with-number sdpi-range {
+	flex: 1 1 auto;
+	min-width: 0;
+}
+
+.range-with-number .range-number-input {
+	flex: 0 0 auto;
+	width: 56px;
+	height: 24px;
+	padding: 2px 6px;
+	border: 1px solid rgba(255, 255, 255, 0.14);
+	border-radius: 4px;
+	background: rgba(255, 255, 255, 0.06);
+	color: #f5f5f5;
+	font: inherit;
+	font-size: 12px;
+	line-height: 1.2;
+	text-align: right;
+	box-sizing: border-box;
+	-moz-appearance: textfield;
+}
+
+.range-with-number .range-number-input::-webkit-outer-spin-button,
+.range-with-number .range-number-input::-webkit-inner-spin-button {
+	-webkit-appearance: none;
+	margin: 0;
+}
+
+.range-with-number .range-number-input:focus {
+	outline: none;
+	border-color: rgba(255, 255, 255, 0.3);
+	background: rgba(255, 255, 255, 0.08);
+}

--- a/com.felixgeelhaar.govee-light-management.sdPlugin/ui/js/range-value.js
+++ b/com.felixgeelhaar.govee-light-management.sdPlugin/ui/js/range-value.js
@@ -2,8 +2,108 @@
  * Shows the current value on sdpi-range sliders in real time.
  * Reaches into the shadow DOM to listen for native input events on the
  * underlying <input type="range">, then updates the sdpi-item label.
+ *
+ * When a slider has data-number-input, also attaches a compact number
+ * input next to it for direct value entry (requested in #200). The two
+ * controls stay in sync: typing updates the slider, dragging updates
+ * the number. Both persist to the sdpi-setting via the slider's native
+ * shadow-root input dispatch.
  */
 (function () {
+	function clamp(val, min, max) {
+		if (typeof val !== "number" || Number.isNaN(val)) return null;
+		if (typeof min === "number" && val < min) return min;
+		if (typeof max === "number" && val > max) return max;
+		return val;
+	}
+
+	function getNativeInput(range) {
+		var shadow = range.shadowRoot;
+		if (!shadow) return null;
+		return shadow.querySelector("input[type=range]");
+	}
+
+	/**
+	 * Persist a value through the slider's native input so SDPI saves it.
+	 * Dispatching a bubbling input+change on the shadow-root input is how
+	 * sdpi-range notices user changes.
+	 */
+	function setSliderValue(range, numericValue) {
+		var nativeInput = getNativeInput(range);
+		if (!nativeInput) return false;
+		var str = String(numericValue);
+		if (nativeInput.value === str) return true;
+		nativeInput.value = str;
+		nativeInput.dispatchEvent(new Event("input", { bubbles: true }));
+		nativeInput.dispatchEvent(new Event("change", { bubbles: true }));
+		return true;
+	}
+
+	function attachNumberInput(range, onValueChange) {
+		if (range.dataset.numberInputAttached === "true") return null;
+		var min = parseFloat(range.getAttribute("min"));
+		var max = parseFloat(range.getAttribute("max"));
+		var step = parseFloat(range.getAttribute("step")) || 1;
+
+		var numberInput = document.createElement("input");
+		numberInput.type = "number";
+		numberInput.className = "range-number-input";
+		if (!Number.isNaN(min)) numberInput.min = String(min);
+		if (!Number.isNaN(max)) numberInput.max = String(max);
+		numberInput.step = String(step);
+		numberInput.inputMode = "numeric";
+		numberInput.setAttribute("aria-label", (range.getAttribute("setting") || "value") + " value");
+
+		// Wrap the slider + number in a flex container for alignment.
+		var wrap = document.createElement("div");
+		wrap.className = "range-with-number";
+		var parent = range.parentNode;
+		if (!parent) return null;
+		parent.insertBefore(wrap, range);
+		wrap.appendChild(range);
+		wrap.appendChild(numberInput);
+
+		range.dataset.numberInputAttached = "true";
+
+		function commit(raw) {
+			var parsed = parseFloat(raw);
+			var clamped = clamp(parsed, min, max);
+			if (clamped === null) return;
+			if (!Number.isNaN(step) && step > 0) {
+				clamped = Math.round(clamped / step) * step;
+				// Re-clamp in case rounding pushed past max/min.
+				clamped = clamp(clamped, min, max);
+			}
+			if (numberInput.value !== String(clamped)) {
+				numberInput.value = String(clamped);
+			}
+			setSliderValue(range, clamped);
+			if (typeof onValueChange === "function") onValueChange(String(clamped));
+		}
+
+		numberInput.addEventListener("change", function () {
+			commit(numberInput.value);
+		});
+		numberInput.addEventListener("blur", function () {
+			commit(numberInput.value);
+		});
+		numberInput.addEventListener("keydown", function (evt) {
+			if (evt.key === "Enter") {
+				evt.preventDefault();
+				commit(numberInput.value);
+				numberInput.blur();
+			}
+		});
+
+		return {
+			syncFromSlider: function (val) {
+				if (val != null && val !== "" && document.activeElement !== numberInput) {
+					numberInput.value = String(val);
+				}
+			},
+		};
+	}
+
 	function init() {
 		document.querySelectorAll("sdpi-range[data-suffix]").forEach(function (range) {
 			var suffix = range.getAttribute("data-suffix") || "";
@@ -12,31 +112,34 @@
 
 			var baseLabel = item.getAttribute("label") || "";
 			var attached = false;
+			var hasNumberInput = range.hasAttribute("data-number-input");
+			var numberBridge = null;
 
 			function update(val) {
 				if (val != null && val !== "") {
 					item.setAttribute("label", baseLabel + " \u00B7 " + val + suffix);
+					if (numberBridge) numberBridge.syncFromSlider(val);
 				}
 			}
 
 			function readValue() {
 				// Prefer shadow DOM input value, fall back to component value
-				var shadow = range.shadowRoot;
-				if (shadow) {
-					var input = shadow.querySelector("input[type=range]");
-					if (input) return input.value;
-				}
+				var nativeInput = getNativeInput(range);
+				if (nativeInput) return nativeInput.value;
 				return range.value;
 			}
 
 			function tryAttach() {
-				var shadow = range.shadowRoot;
-				if (!shadow) return false;
-				var input = shadow.querySelector("input[type=range]");
-				if (!input) return false;
-				input.addEventListener("input", function () {
-					update(input.value);
+				var nativeInput = getNativeInput(range);
+				if (!nativeInput) return false;
+				nativeInput.addEventListener("input", function () {
+					update(nativeInput.value);
 				});
+				if (hasNumberInput && !numberBridge) {
+					numberBridge = attachNumberInput(range, update);
+					// Initial sync for newly-created number input.
+					numberBridge.syncFromSlider(nativeInput.value);
+				}
 				return true;
 			}
 

--- a/com.felixgeelhaar.govee-light-management.sdPlugin/ui/saturation-dial.html
+++ b/com.felixgeelhaar.govee-light-management.sdPlugin/ui/saturation-dial.html
@@ -29,6 +29,7 @@
           step="1"
           showlabels
           data-suffix="%"
+          data-number-input
         >
           <span slot="min">Fine</span>
           <span slot="max">Coarse</span>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "govee-light-management",
-  "version": "2.4.0",
+  "version": "2.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "govee-light-management",
-      "version": "2.4.0",
+      "version": "2.4.2",
       "license": "MIT",
       "dependencies": {
         "@elgato/streamdeck": "^2.0.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "govee-light-management",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "description": "Enterprise-grade Stream Deck plugin for managing Govee lights with advanced group functionality",
   "main": "com.felixgeelhaar.govee-light-management.sdPlugin/bin/plugin.js",
   "scripts": {

--- a/test/e2e/range-number-input.spec.ts
+++ b/test/e2e/range-number-input.spec.ts
@@ -1,0 +1,134 @@
+/**
+ * E2E tests for the paired slider + number input on Property Inspectors
+ * (#200). Ensures every PI that opts in with data-number-input gets a
+ * working number input alongside the slider and that the two stay in sync.
+ */
+import { test, expect, type Page } from "@playwright/test";
+
+const RANGE_WITH_NUMBER_INPUT = [
+  { name: "Brightness", url: "/ui/brightness.html", setting: "brightnessValue" },
+  { name: "Color Temperature", url: "/ui/color-temperature.html", setting: "colorTempValue" },
+  { name: "Saturation Dial stepSize", url: "/ui/saturation-dial.html", setting: "stepSize" },
+];
+
+async function waitForRangeReady(page: Page, setting: string) {
+  // sdpi-range needs a moment to attach its shadow DOM + for the poll in
+  // range-value.js to insert the number input. 500ms tops.
+  await page.waitForFunction(
+    (s: string) => {
+      const range = document.querySelector<HTMLElement>(`sdpi-range[setting="${s}"]`);
+      if (!range) return false;
+      const wrap = range.closest<HTMLElement>(".range-with-number");
+      const numberInput = wrap?.querySelector<HTMLInputElement>(".range-number-input");
+      return !!(numberInput && numberInput.value !== "");
+    },
+    setting,
+    { timeout: 5_000 },
+  );
+}
+
+/**
+ * PIs hide the #settings panel until SDPI reports a valid API key. In the
+ * test environment there's no real Stream Deck backend, so the panel stays
+ * hidden and .range-number-input isn't interactable. Force the panel
+ * visible for sync-behavior tests.
+ */
+async function revealSettingsPanel(page: Page) {
+  await page.evaluate(() => {
+    document.getElementById("settings")?.classList.remove("hidden");
+    document.getElementById("setup")?.classList.add("hidden");
+  });
+}
+
+for (const { name, url, setting } of RANGE_WITH_NUMBER_INPUT) {
+  test.describe(`${name} number input`, () => {
+    test("renders a number input next to the slider", async ({ page }) => {
+      await page.goto(url);
+      await waitForRangeReady(page, setting);
+
+      const wrap = page.locator(`.range-with-number:has(sdpi-range[setting="${setting}"])`);
+      await expect(wrap).toBeAttached();
+
+      const numberInput = wrap.locator(".range-number-input");
+      await expect(numberInput).toBeAttached();
+      await expect(numberInput).toHaveAttribute("type", "number");
+    });
+
+    test("number input inherits min/max/step from the slider", async ({ page }) => {
+      await page.goto(url);
+      await waitForRangeReady(page, setting);
+
+      const slider = page.locator(`sdpi-range[setting="${setting}"]`);
+      const min = await slider.getAttribute("min");
+      const max = await slider.getAttribute("max");
+      const step = await slider.getAttribute("step");
+
+      const numberInput = page.locator(
+        `.range-with-number:has(sdpi-range[setting="${setting}"]) .range-number-input`,
+      );
+      await expect(numberInput).toHaveAttribute("min", min ?? "");
+      await expect(numberInput).toHaveAttribute("max", max ?? "");
+      await expect(numberInput).toHaveAttribute("step", step ?? "1");
+    });
+  });
+}
+
+test.describe("range-number-input sync behavior (brightness)", () => {
+  test("typing a value in the number input updates the slider's underlying input", async ({ page }) => {
+    await page.goto("/ui/brightness.html");
+    await waitForRangeReady(page, "brightnessValue");
+    await revealSettingsPanel(page);
+
+    await page.locator(".range-with-number .range-number-input").fill("73");
+    await page.locator(".range-with-number .range-number-input").press("Enter");
+
+    const sliderValue = await page.evaluate(() => {
+      const range = document.querySelector<HTMLElement>('sdpi-range[setting="brightnessValue"]');
+      const nativeInput =
+        range?.shadowRoot?.querySelector<HTMLInputElement>('input[type="range"]');
+      return nativeInput?.value;
+    });
+    expect(sliderValue).toBe("73");
+  });
+
+  test("typing a value above max clamps to max (happy-path validation)", async ({ page }) => {
+    await page.goto("/ui/brightness.html");
+    await waitForRangeReady(page, "brightnessValue");
+    await revealSettingsPanel(page);
+
+    const numberInput = page.locator(".range-with-number .range-number-input");
+    await numberInput.fill("999");
+    await numberInput.press("Enter");
+
+    // After clamp the number input shows the max (100 for brightness).
+    await expect(numberInput).toHaveValue("100");
+
+    const sliderValue = await page.evaluate(() => {
+      const range = document.querySelector<HTMLElement>('sdpi-range[setting="brightnessValue"]');
+      const nativeInput =
+        range?.shadowRoot?.querySelector<HTMLInputElement>('input[type="range"]');
+      return nativeInput?.value;
+    });
+    expect(sliderValue).toBe("100");
+  });
+
+  test("typing a value below min clamps to min", async ({ page }) => {
+    await page.goto("/ui/brightness.html");
+    await waitForRangeReady(page, "brightnessValue");
+    await revealSettingsPanel(page);
+
+    const numberInput = page.locator(".range-with-number .range-number-input");
+    await numberInput.fill("-50");
+    await numberInput.press("Enter");
+
+    await expect(numberInput).toHaveValue("0");
+  });
+
+  test("PIs without data-number-input don't get a number input (on-off has none)", async ({ page }) => {
+    await page.goto("/ui/on-off.html");
+    // On-off has no sliders at all, but explicitly confirm the helper
+    // doesn't create spurious number inputs on unrelated PIs.
+    await page.waitForLoadState("domcontentloaded");
+    await expect(page.locator(".range-number-input")).toHaveCount(0);
+  });
+});


### PR DESCRIPTION
Closes #200.

## Summary
Adds a compact number input next to sdpi-range sliders on Brightness, Color Temperature, and Saturation Dial stepSize so users can type a precise value instead of fiddling with the slider for exact entries.

## How it works
- sdpi-range that opt in with `data-number-input` get a styled `<input type="number">` inserted via `range-value.js`
- Bidirectional sync through the shadow-root native input dispatch — slider and number always reflect the same value
- On commit (change, blur, Enter), the value is clamped to min/max and snapped to step before persisting
- No changes to backend or settings shape — existing sliders behave identically

## Test plan
- [x] type-check, lint, build, `streamdeck validate` all green
- [x] 492 unit tests pass (unchanged)
- [x] 128 E2E tests pass (up from 118 — 10 new covering input presence, attribute inheritance, sync behavior, clamping, and that PIs without the opt-in don't get a number input)
- [x] Visually verified via the existing E2E infrastructure

## Release
Ships as v2.4.2 on GitHub. Marketplace stays on v2.4.0 (in review) until that submission clears, then v2.4.2 supersedes it.