### PR TITLE
refactor: 3 quality cleanups from the DDD/SOLID audit

### DIFF
--- a/src/backend/actions/shared/ActionServices.ts
+++ b/src/backend/actions/shared/ActionServices.ts
@@ -1073,14 +1073,22 @@ export class ActionServices {
     if (!this.lightRepository) {
       throw new Error("Light repository not initialized");
     }
-    return this.lightRepository.getDynamicScenes(light);
+    return withTimeout(
+      this.lightRepository.getDynamicScenes(light),
+      PI_HANDLER_TIMEOUT_MS,
+      "Dynamic scenes fetch",
+    );
   }
 
   async getDiyScenes(light: Light): Promise<DiyScene[]> {
     if (!this.lightRepository) {
       throw new Error("Light repository not initialized");
     }
-    return this.lightRepository.getDiyScenes(light);
+    return withTimeout(
+      this.lightRepository.getDiyScenes(light),
+      PI_HANDLER_TIMEOUT_MS,
+      "DIY scenes fetch",
+    );
   }
 
   async applyDynamicScene(light: Light, scene: LightScene): Promise<void> {
@@ -1101,7 +1109,11 @@ export class ActionServices {
     if (!this.lightRepository) {
       throw new Error("Light repository not initialized");
     }
-    return this.lightRepository.getSnapshots(light);
+    return withTimeout(
+      this.lightRepository.getSnapshots(light),
+      PI_HANDLER_TIMEOUT_MS,
+      "Snapshots fetch",
+    );
   }
 
   async applySnapshot(light: Light, snapshot: Snapshot): Promise<void> {
@@ -1310,7 +1322,11 @@ export class ActionServices {
     if (!this.lightRepository) {
       throw new Error("Light repository not initialized");
     }
-    return this.lightRepository.getMusicModes(deviceId);
+    return withTimeout(
+      this.lightRepository.getMusicModes(deviceId),
+      PI_HANDLER_TIMEOUT_MS,
+      "Music modes fetch",
+    );
   }
 
   async getToggleFeatures(
@@ -1319,7 +1335,11 @@ export class ActionServices {
     if (!this.lightRepository) {
       throw new Error("Light repository not initialized");
     }
-    return this.lightRepository.getToggleFeatures(deviceId);
+    return withTimeout(
+      this.lightRepository.getToggleFeatures(deviceId),
+      PI_HANDLER_TIMEOUT_MS,
+      "Toggle features fetch",
+    );
   }
 
   private getLiveStateKey(light: Light, operation: string): string {

--- a/src/backend/connectivity/cloud/CloudTransport.ts
+++ b/src/backend/connectivity/cloud/CloudTransport.ts
@@ -7,6 +7,7 @@ import {
 } from "@felixgeelhaar/govee-api-client";
 
 import type { LightItem, LightState } from "@shared/types";
+import { UNSUPPORTED_CLOUD_GROUP_MODELS } from "@shared/cloud-groups";
 import type { ITransport } from "../ITransport";
 import {
   ControlCommand,
@@ -32,12 +33,6 @@ const factory: ClientFactory = {
     });
   },
 };
-
-const UNSUPPORTED_CLOUD_GROUP_MODELS = new Set([
-  "BaseGroup",
-  "SameModelGroup",
-  "SameModeGroup",
-]);
 
 export class CloudTransport implements ITransport {
   readonly descriptor: TransportDescriptor = {

--- a/src/backend/infrastructure/mappers/music-mode-options.ts
+++ b/src/backend/infrastructure/mappers/music-mode-options.ts
@@ -1,0 +1,130 @@
+/**
+ * Pure parser that extracts music-mode options from a Govee device's
+ * capability list.
+ *
+ * Govee's `/router/api/v1/user/devices` response exposes music modes in
+ * at least three observed shapes:
+ *
+ *  1. Flat: `parameters.options = [{ name, value: <number> }]`
+ *  2. Nested: `parameters.fields = [{ fieldName: "musicMode", options: [...] }]`
+ *  3. Object values: `option.value = { musicMode: N }` or `{ modeId: N }`
+ *     or `{ id: N }`
+ *
+ * This parser handles all three without the repository having to know
+ * the shape. Extracted from `GoveeLightRepository.getMusicModes` so the
+ * repository can focus on device lookup and the parser can grow
+ * independently as new device variants appear.
+ *
+ * Returns a deduplicated list of `{ name, value }` where `value` is the
+ * numeric mode id Govee expects on the control endpoint.
+ */
+
+export interface MusicModeOption {
+  name: string;
+  value: number;
+}
+
+interface CapabilityOptionLike {
+  name?: unknown;
+  value?: unknown;
+}
+
+interface CapabilityFieldLike {
+  fieldName?: unknown;
+  options?: unknown[];
+}
+
+interface CapabilityLike {
+  type: string;
+  instance: string;
+  parameters?: {
+    options?: unknown[];
+    fields?: CapabilityFieldLike[];
+  };
+}
+
+/** Field names Govee has used for the music-mode option list inside a STRUCT. */
+const PREFERRED_FIELD_NAMES = new Set(["musicmode", "modeid", "mode"]);
+
+function extractNumericModeValue(value: unknown): number | null {
+  if (typeof value === "number" && Number.isInteger(value) && value > 0) {
+    return value;
+  }
+
+  if (typeof value === "object" && value !== null) {
+    const record = value as Record<string, unknown>;
+    for (const key of ["musicMode", "modeId", "id"]) {
+      const candidate = record[key];
+      if (
+        typeof candidate === "number" &&
+        Number.isInteger(candidate) &&
+        candidate > 0
+      ) {
+        return candidate;
+      }
+    }
+  }
+
+  return null;
+}
+
+function collect(
+  options: unknown[] | undefined,
+  dedupe: Map<number, MusicModeOption>,
+): void {
+  if (!Array.isArray(options)) return;
+  for (const option of options) {
+    if (typeof option !== "object" || option === null) continue;
+    const record = option as CapabilityOptionLike;
+    const name = typeof record.name === "string" ? record.name.trim() : "";
+    const value = extractNumericModeValue(record.value);
+    if (!name || value === null) continue;
+    dedupe.set(value, { name, value });
+  }
+}
+
+/**
+ * Walk a device's capability list and return every `music_setting` /
+ * `musicMode` option as `{ name, value: modeId }`. Dedupes by value so
+ * the same mode appearing in both `parameters.options` and
+ * `parameters.fields[*].options` collapses to one entry.
+ */
+export function parseMusicModeOptions(
+  capabilities: ReadonlyArray<CapabilityLike>,
+): MusicModeOption[] {
+  const dedupe = new Map<number, MusicModeOption>();
+
+  for (const cap of capabilities) {
+    if (!cap.type.includes("music_setting") || cap.instance !== "musicMode") {
+      continue;
+    }
+
+    const params = cap.parameters;
+    if (!params) continue;
+
+    // Shape 1: flat options directly on parameters.
+    collect(params.options, dedupe);
+
+    if (Array.isArray(params.fields)) {
+      // Shape 2a: fields whose fieldName matches a known mode-option field.
+      for (const field of params.fields) {
+        const fieldName =
+          typeof field?.fieldName === "string"
+            ? field.fieldName.toLowerCase()
+            : "";
+        if (PREFERRED_FIELD_NAMES.has(fieldName)) {
+          collect(field.options, dedupe);
+        }
+      }
+
+      // Shape 2b: unknown field names but still enumerable options.
+      // Fall through so we don't miss modes on devices that rename
+      // the field. Dedup guards against double-counting.
+      for (const field of params.fields) {
+        collect(field?.options, dedupe);
+      }
+    }
+  }
+
+  return Array.from(dedupe.values());
+}

--- a/src/backend/infrastructure/repositories/GoveeLightRepository.ts
+++ b/src/backend/infrastructure/repositories/GoveeLightRepository.ts
@@ -23,13 +23,9 @@ import {
   VALID_TOGGLE_INSTANCES,
 } from "../../actions/shared/validation";
 import { safeGetColorTemperature } from "../utils/deviceStateUtils";
+import { parseMusicModeOptions } from "../mappers/music-mode-options";
+import { UNSUPPORTED_CLOUD_GROUP_MODELS } from "@shared/cloud-groups";
 import streamDeck from "@elgato/streamdeck";
-
-const UNSUPPORTED_CLOUD_GROUP_MODELS = new Set([
-  "BaseGroup",
-  "SameModelGroup",
-  "SameModeGroup",
-]);
 
 export class GoveeLightRepository implements ILightRepository {
   private client: GoveeClient;
@@ -672,100 +668,14 @@ export class GoveeLightRepository implements ILightRepository {
       );
       if (!device) return [];
 
-      const extractModeValue = (value: unknown): number | null => {
-        if (typeof value === "number" && Number.isInteger(value) && value > 0) {
-          return value;
-        }
-
-        if (typeof value === "object" && value !== null) {
-          if (
-            "musicMode" in value &&
-            typeof value.musicMode === "number" &&
-            Number.isInteger(value.musicMode) &&
-            value.musicMode > 0
-          ) {
-            return value.musicMode;
-          }
-
-          if (
-            "modeId" in value &&
-            typeof value.modeId === "number" &&
-            Number.isInteger(value.modeId) &&
-            value.modeId > 0
-          ) {
-            return value.modeId;
-          }
-
-          if (
-            "id" in value &&
-            typeof value.id === "number" &&
-            Number.isInteger(value.id) &&
-            value.id > 0
-          ) {
-            return value.id;
-          }
-        }
-
-        return null;
-      };
-
-      const dedupe = new Map<number, { name: string; value: number }>();
-
-      const addOptions = (options: unknown[] | undefined) => {
-        if (!Array.isArray(options)) return;
-        for (const option of options) {
-          if (typeof option !== "object" || option === null) continue;
-          const optionRecord = option as { name?: unknown; value?: unknown };
-          const name =
-            typeof optionRecord.name === "string"
-              ? optionRecord.name.trim()
-              : "";
-          const value = extractModeValue(optionRecord.value);
-          if (!name || value === null) continue;
-          dedupe.set(value, { name, value });
-        }
-      };
-
-      for (const cap of device.capabilities) {
-        if (
-          !cap.type.includes("music_setting") ||
-          cap.instance !== "musicMode"
-        ) {
-          continue;
-        }
-
-        const params = cap.parameters as any;
-
-        // Some devices expose music modes directly on parameters.options.
-        addOptions(params?.options);
-
-        // Others expose them under a field, typically alongside sensitivity.
-        if (Array.isArray(params?.fields)) {
-          const preferredFields = params.fields.filter((field: any) => {
-            const fieldName =
-              typeof field?.fieldName === "string"
-                ? field.fieldName.toLowerCase()
-                : "";
-            return (
-              fieldName === "musicmode" ||
-              fieldName === "modeid" ||
-              fieldName === "mode"
-            );
-          });
-
-          for (const field of preferredFields) {
-            addOptions(field?.options);
-          }
-
-          // Fallback for devices that use a different field name but still
-          // carry enumerable mode options in the first field.
-          for (const field of params.fields) {
-            addOptions(field?.options);
-          }
-        }
-      }
-
-      return Array.from(dedupe.values());
+      // Delegate the actual capability parsing to the pure parser —
+      // see `infrastructure/mappers/music-mode-options.ts`. The
+      // repository's job is just device lookup and error translation.
+      return parseMusicModeOptions(
+        device.capabilities as unknown as Parameters<
+          typeof parseMusicModeOptions
+        >[0],
+      );
     } catch (error) {
       streamDeck.logger.error("Failed to get music modes:", error);
       return [];

--- a/src/shared/cloud-groups.ts
+++ b/src/shared/cloud-groups.ts
@@ -1,0 +1,26 @@
+/**
+ * Govee cloud-side "pseudo-group" device models that appear in
+ * /router/api/v1/user/devices but are NOT controllable through the
+ * public control API. Selecting one as a target silently fails every
+ * command (#186, #188 — fixed in #189).
+ *
+ * These entries are filtered out of device discovery at the transport
+ * and repository boundaries, and the Property Inspector surfaces a
+ * clear hint if a stale setting still points at one.
+ *
+ * Shared between CloudTransport and GoveeLightRepository so both
+ * filtering paths stay in sync. If Govee adds more pseudo-group
+ * model names in the future, add them here once.
+ */
+export const UNSUPPORTED_CLOUD_GROUP_MODELS: ReadonlySet<string> = new Set([
+  "BaseGroup",
+  "SameModelGroup",
+  "SameModeGroup",
+]);
+
+/**
+ * Type-narrow helper so callers don't have to repeat the cast.
+ */
+export function isUnsupportedCloudGroup(model: string | undefined): boolean {
+  return typeof model === "string" && UNSUPPORTED_CLOUD_GROUP_MODELS.has(model);
+}

--- a/test/infrastructure/mappers/music-mode-options.test.ts
+++ b/test/infrastructure/mappers/music-mode-options.test.ts
@@ -1,0 +1,186 @@
+import { describe, expect, it } from "vitest";
+import { parseMusicModeOptions } from "../../../src/backend/infrastructure/mappers/music-mode-options";
+
+describe("parseMusicModeOptions", () => {
+  it("returns empty when no music_setting capability is present", () => {
+    const result = parseMusicModeOptions([
+      {
+        type: "devices.capabilities.on_off",
+        instance: "powerSwitch",
+        parameters: { options: [{ name: "on", value: 1 }] },
+      },
+    ]);
+    expect(result).toEqual([]);
+  });
+
+  it("extracts flat options shape (parameters.options)", () => {
+    const result = parseMusicModeOptions([
+      {
+        type: "devices.capabilities.music_setting",
+        instance: "musicMode",
+        parameters: {
+          options: [
+            { name: "Rhythm", value: 3 },
+            { name: "Spectrum", value: 4 },
+          ],
+        },
+      },
+    ]);
+    expect(result).toEqual([
+      { name: "Rhythm", value: 3 },
+      { name: "Spectrum", value: 4 },
+    ]);
+  });
+
+  it("extracts from a named STRUCT field (parameters.fields[musicMode].options)", () => {
+    const result = parseMusicModeOptions([
+      {
+        type: "devices.capabilities.music_setting",
+        instance: "musicMode",
+        parameters: {
+          fields: [
+            {
+              fieldName: "musicMode",
+              options: [{ name: "Energic", value: 5 }],
+            },
+            {
+              fieldName: "sensitivity",
+              // range field, not a mode-options carrier
+            },
+          ],
+        },
+      },
+    ]);
+    expect(result).toEqual([{ name: "Energic", value: 5 }]);
+  });
+
+  it("accepts modeId and id field-name aliases (case-insensitive)", () => {
+    const result = parseMusicModeOptions([
+      {
+        type: "devices.capabilities.music_setting",
+        instance: "musicMode",
+        parameters: {
+          fields: [
+            {
+              fieldName: "MODEID",
+              options: [{ name: "Rolling", value: 6 }],
+            },
+          ],
+        },
+      },
+    ]);
+    expect(result).toEqual([{ name: "Rolling", value: 6 }]);
+  });
+
+  it("unwraps object values like { musicMode: N } / { modeId: N } / { id: N }", () => {
+    const result = parseMusicModeOptions([
+      {
+        type: "devices.capabilities.music_setting",
+        instance: "musicMode",
+        parameters: {
+          options: [
+            { name: "A", value: { musicMode: 3 } },
+            { name: "B", value: { modeId: 5 } },
+            { name: "C", value: { id: 7 } },
+          ],
+        },
+      },
+    ]);
+    expect(result).toEqual([
+      { name: "A", value: 3 },
+      { name: "B", value: 5 },
+      { name: "C", value: 7 },
+    ]);
+  });
+
+  it("dedupes the same value across flat + field shapes", () => {
+    const result = parseMusicModeOptions([
+      {
+        type: "devices.capabilities.music_setting",
+        instance: "musicMode",
+        parameters: {
+          options: [{ name: "Rhythm", value: 3 }],
+          fields: [
+            {
+              fieldName: "musicMode",
+              options: [
+                { name: "Rhythm", value: 3 },
+                { name: "Spectrum", value: 4 },
+              ],
+            },
+          ],
+        },
+      },
+    ]);
+    expect(result).toHaveLength(2);
+    expect(result.map((r) => r.value).sort()).toEqual([3, 4]);
+  });
+
+  it("skips malformed entries (missing name, non-integer, zero, negative)", () => {
+    const result = parseMusicModeOptions([
+      {
+        type: "devices.capabilities.music_setting",
+        instance: "musicMode",
+        parameters: {
+          options: [
+            { name: "", value: 3 }, // empty name
+            { name: "Valid", value: 4 },
+            { name: "Zero", value: 0 }, // not positive
+            { name: "Negative", value: -1 },
+            { name: "Float", value: 3.5 }, // not integer
+            { name: "String", value: "5" }, // wrong type
+            { name: "Null", value: null },
+            { name: "NoValue" }, // missing value
+          ],
+        },
+      },
+    ]);
+    expect(result).toEqual([{ name: "Valid", value: 4 }]);
+  });
+
+  it("falls back to any enumerable field when no known fieldName matches", () => {
+    // Devices in the wild have been seen using renamed fields; we
+    // accept them after the preferred lookup as a defensive fallback.
+    const result = parseMusicModeOptions([
+      {
+        type: "devices.capabilities.music_setting",
+        instance: "musicMode",
+        parameters: {
+          fields: [
+            {
+              fieldName: "completelyUnexpected",
+              options: [{ name: "Rhythm", value: 3 }],
+            },
+          ],
+        },
+      },
+    ]);
+    expect(result).toEqual([{ name: "Rhythm", value: 3 }]);
+  });
+
+  it("trims surrounding whitespace from option names", () => {
+    const result = parseMusicModeOptions([
+      {
+        type: "devices.capabilities.music_setting",
+        instance: "musicMode",
+        parameters: {
+          options: [{ name: "  Rhythm  ", value: 3 }],
+        },
+      },
+    ]);
+    expect(result[0].name).toBe("Rhythm");
+  });
+
+  it("ignores capabilities with the right type but wrong instance", () => {
+    const result = parseMusicModeOptions([
+      {
+        type: "devices.capabilities.music_setting",
+        instance: "musicBass", // not musicMode
+        parameters: {
+          options: [{ name: "Boom", value: 99 }],
+        },
+      },
+    ]);
+    expect(result).toEqual([]);
+  });
+});


### PR DESCRIPTION
Internal quality work from the DDD/SOLID audit of the v2.4.x merges. No user-visible change, no new features, no bug fixes. Good use of the marketplace-review waiting window.

## Three findings addressed

### 1. Shared \`UNSUPPORTED_CLOUD_GROUP_MODELS\` constant
The Set was duplicated at \`CloudTransport.ts:36\` and \`GoveeLightRepository.ts:28\` (introduced together in #189). Extracted to \`src/shared/cloud-groups.ts\` so the two filtering paths can't drift if Govee adds new pseudo-group model names.

### 2. Pure \`parseMusicModeOptions\` parser
\`GoveeLightRepository.getMusicModes\` was 110 lines mixing device lookup, capability filtering, value extraction across three observed response shapes, field-name preference, and dedup. Single-responsibility violation — the repository's job is device lookup, not response parsing.

Extracted to \`src/backend/infrastructure/mappers/music-mode-options.ts\` as a pure function. Repository method now ~15 lines: lookup → delegate → error translate. Follows the \`scene-items.ts\` pattern from #181.

### 3. Timeouts on all dependent-dropdown fetches
Only \`handleGetDevices\` + \`handleGetDeviceDebug\` wrapped their calls in \`withTimeout()\`. The other dropdown datasources (\`getDynamicScenes\`, \`getDiyScenes\`, \`getSnapshots\`, \`getMusicModes\`, \`getToggleFeatures\`) would hang the PI indefinitely on a stuck Govee API call. Now wrapped at the ActionServices layer so every caller gets the 10s timeout.

## Test plan
- [x] \`npm run type-check\` / \`lint\`
- [x] \`npm test\` — 502 unit tests pass (up from 492; 10 new for \`parseMusicModeOptions\` covering each shape variant, dedup, and graceful handling of malformed entries)
- [x] \`npx playwright test\` — 128 E2E pass (unchanged)
- [x] \`npm run build\` + rollup validation pass

## Release
Not tagged. Rolls into the next user-facing release (v2.4.3 or v2.5.0) alongside those features.