### PR TITLE
chore: release v2.4.3 — dreamViewToggle command route fix

### DIFF
--- a/com.felixgeelhaar.govee-light-management.sdPlugin/manifest.json
+++ b/com.felixgeelhaar.govee-light-management.sdPlugin/manifest.json
@@ -1,6 +1,6 @@
 {
   "Name": "Govee Light Management",
-  "Version": "2.4.2.0",
+  "Version": "2.4.3.0",
   "Author": "Felix Geelhaar",
   "URL": "https://github.com/felixgeelhaar/govee-light-management",
   "SupportURL": "https://github.com/felixgeelhaar/govee-light-management/issues",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@elgato/streamdeck": "^2.0.4",
-        "@felixgeelhaar/govee-api-client": "^3.3.2",
+        "@felixgeelhaar/govee-api-client": "^3.3.3",
         "zod": "4.3.5"
       },
       "devDependencies": {
@@ -577,9 +577,9 @@
       }
     },
     "node_modules/@felixgeelhaar/govee-api-client": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/@felixgeelhaar/govee-api-client/-/govee-api-client-3.3.2.tgz",
-      "integrity": "sha512-BoTDI46qV3E84XNn1oxyuu0fhQO2aUmknp5emZBW6SY++b2/hN1BkwOed76zP5Ba5ktHXCPBSzMlHCEvggjWDw==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/@felixgeelhaar/govee-api-client/-/govee-api-client-3.3.3.tgz",
+      "integrity": "sha512-P4D8fNOEYOS1eQFdGSBbJQvEqmyuG/IuqrtNt1jP3RtiuLeQhgAfhkN7+xVHiV1R/ubtVRxFtDCkBuUW8oD/iQ==",
       "license": "MIT",
       "dependencies": {
         "axios": "1.15.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "govee-light-management",
-  "version": "2.4.2",
+  "version": "2.4.3",
   "description": "Enterprise-grade Stream Deck plugin for managing Govee lights with advanced group functionality",
   "main": "com.felixgeelhaar.govee-light-management.sdPlugin/bin/plugin.js",
   "scripts": {
@@ -61,7 +61,7 @@
   },
   "dependencies": {
     "@elgato/streamdeck": "^2.0.4",
-    "@felixgeelhaar/govee-api-client": "^3.3.2",
+    "@felixgeelhaar/govee-api-client": "^3.3.3",
     "zod": "4.3.5"
   },
   "overrides": {


### PR DESCRIPTION
Bumps `@felixgeelhaar/govee-api-client` to 3.3.3 which fixes the capability-type route for `dreamViewToggle` (and any future Govee toggle / mode instance via suffix fallback).

Rolls up the internal quality refactors from PR #204 (shared cloud-group constant, extracted music-mode parser, PI-fetch timeouts) which landed on main after v2.4.2.

## Test plan
- [x] type-check / lint / tests / build / streamdeck validate all green
- [x] 502 unit + 128 E2E pass
- [x] client v3.3.3 confirmed installed in node_modules