### PR TITLE
fix(music-modes): H70B6 0-indexed modes + manifest bump (closes #250)

### DIFF
--- a/com.felixgeelhaar.govee-light-management.sdPlugin/manifest.json
+++ b/com.felixgeelhaar.govee-light-management.sdPlugin/manifest.json
@@ -1,6 +1,6 @@
 {
   "Name": "Govee Light Management",
-  "Version": "2.7.5.0",
+  "Version": "2.7.7.0",
   "Author": "Felix Geelhaar",
   "URL": "https://github.com/felixgeelhaar/govee-light-management",
   "SupportURL": "https://github.com/felixgeelhaar/govee-light-management/issues",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "govee-light-management",
-  "version": "2.7.6",
+  "version": "2.7.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "govee-light-management",
-      "version": "2.7.6",
+      "version": "2.7.7",
       "license": "MIT",
       "dependencies": {
         "@elgato/streamdeck": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "govee-light-management",
-  "version": "2.7.6",
+  "version": "2.7.7",
   "description": "Enterprise-grade Stream Deck plugin for managing Govee lights with advanced group functionality",
   "main": "com.felixgeelhaar.govee-light-management.sdPlugin/bin/plugin.js",
   "scripts": {

--- a/src/backend/infrastructure/mappers/music-mode-options.ts
+++ b/src/backend/infrastructure/mappers/music-mode-options.ts
@@ -47,7 +47,9 @@ interface CapabilityLike {
 const PREFERRED_FIELD_NAMES = new Set(["musicmode", "modeid", "mode"]);
 
 function extractNumericModeValue(value: unknown): number | null {
-  if (typeof value === "number" && Number.isInteger(value) && value > 0) {
+  // Mode ids are non-negative integers. Some devices (e.g. Curtain Lights
+  // Pro H70B6) are 0-indexed — "Floating Mist" is mode 0 — so 0 is valid.
+  if (typeof value === "number" && Number.isInteger(value) && value >= 0) {
     return value;
   }
 
@@ -58,7 +60,7 @@ function extractNumericModeValue(value: unknown): number | null {
       if (
         typeof candidate === "number" &&
         Number.isInteger(candidate) &&
-        candidate > 0
+        candidate >= 0
       ) {
         return candidate;
       }
@@ -107,6 +109,7 @@ export function parseMusicModeOptions(
 
     if (Array.isArray(params.fields)) {
       // Shape 2a: fields whose fieldName matches a known mode-option field.
+      let matchedPreferredField = false;
       for (const field of params.fields) {
         const fieldName =
           typeof field?.fieldName === "string"
@@ -114,14 +117,19 @@ export function parseMusicModeOptions(
             : "";
         if (PREFERRED_FIELD_NAMES.has(fieldName)) {
           collect(field.options, dedupe);
+          matchedPreferredField = true;
         }
       }
 
-      // Shape 2b: unknown field names but still enumerable options.
-      // Fall through so we don't miss modes on devices that rename
-      // the field. Dedup guards against double-counting.
-      for (const field of params.fields) {
-        collect(field?.options, dedupe);
+      // Shape 2b: only when NO preferred field was found, fall back to any
+      // enumerable field for devices that rename the mode field. We must
+      // NOT do this when a proper `musicMode` field exists — sibling STRUCT
+      // fields like `autoColor` (on=1/off=0) would otherwise collide on
+      // value with real modes and overwrite them (e.g. Spectrum=1). See #250.
+      if (!matchedPreferredField) {
+        for (const field of params.fields) {
+          collect(field?.options, dedupe);
+        }
       }
     }
   }

--- a/test/infrastructure/mappers/music-mode-options.test.ts
+++ b/test/infrastructure/mappers/music-mode-options.test.ts
@@ -116,7 +116,7 @@ describe("parseMusicModeOptions", () => {
     expect(result.map((r) => r.value).sort()).toEqual([3, 4]);
   });
 
-  it("skips malformed entries (missing name, non-integer, zero, negative)", () => {
+  it("skips malformed entries (missing name, non-integer, negative)", () => {
     const result = parseMusicModeOptions([
       {
         type: "devices.capabilities.music_setting",
@@ -125,8 +125,8 @@ describe("parseMusicModeOptions", () => {
           options: [
             { name: "", value: 3 }, // empty name
             { name: "Valid", value: 4 },
-            { name: "Zero", value: 0 }, // not positive
-            { name: "Negative", value: -1 },
+            { name: "Zero", value: 0 }, // 0 is a legitimate 0-indexed mode id
+            { name: "Negative", value: -1 }, // negative is invalid
             { name: "Float", value: 3.5 }, // not integer
             { name: "String", value: "5" }, // wrong type
             { name: "Null", value: null },
@@ -135,7 +135,75 @@ describe("parseMusicModeOptions", () => {
         },
       },
     ]);
-    expect(result).toEqual([{ name: "Valid", value: 4 }]);
+    // value 0 is valid (Govee uses 0-indexed mode ids on some devices).
+    expect(result).toEqual([
+      { name: "Valid", value: 4 },
+      { name: "Zero", value: 0 },
+    ]);
+  });
+
+  it("returns all H70B6 music modes including value-0, no field pollution (#250)", () => {
+    // Real Curtain Lights Pro (H70B6) payload: STRUCT whose musicMode field
+    // is 0-indexed (Floating Mist=0, Spectrum=1) plus unrelated fields
+    // (autoColor on=1/off=0, sensitivity, rgb). Previously Floating Mist was
+    // dropped (value 0 rejected) and Spectrum was overwritten by autoColor
+    // "on" (value 1) via the field fallback.
+    const result = parseMusicModeOptions([
+      {
+        type: "devices.capabilities.music_setting",
+        instance: "musicMode",
+        parameters: {
+          dataType: "STRUCT",
+          fields: [
+            {
+              fieldName: "musicMode",
+              dataType: "ENUM",
+              options: [
+                { name: "Floating Mist", value: 0 },
+                { name: "Spectrum", value: 1 },
+                { name: "Separation", value: 2 },
+                { name: "Meteor shower", value: 3 },
+                { name: "Hopping", value: 4 },
+                { name: "Shrink", value: 5 },
+                { name: "Sound Wave", value: 6 },
+                { name: "Falling Sand", value: 7 },
+                { name: "Color Flip", value: 8 },
+                { name: "Christmas Night", value: 9 },
+              ],
+            },
+            {
+              fieldName: "sensitivity",
+              dataType: "INTEGER",
+              range: { min: 0, max: 100, precision: 1 },
+            },
+            {
+              fieldName: "autoColor",
+              dataType: "ENUM",
+              options: [
+                { name: "on", value: 1 },
+                { name: "off", value: 0 },
+              ],
+            },
+            {
+              fieldName: "rgb",
+              dataType: "INTEGER",
+              range: { min: 0, max: 16777215, precision: 1 },
+            },
+          ],
+        },
+      },
+    ]);
+
+    const names = result.map((m) => m.name);
+    expect(result).toHaveLength(10);
+    expect(names).toContain("Floating Mist");
+    expect(names).toContain("Spectrum");
+    // autoColor values must not leak in as "modes".
+    expect(names).not.toContain("on");
+    expect(names).not.toContain("off");
+    // Real values preserved (not overwritten by autoColor).
+    expect(result.find((m) => m.name === "Floating Mist")?.value).toBe(0);
+    expect(result.find((m) => m.name === "Spectrum")?.value).toBe(1);
   });
 
   it("falls back to any enumerable field when no known fieldName matches", () => {


### PR DESCRIPTION
Closes #250 with the reporter's confirmed H70B6 capability dump.

**Root cause** — two bugs hid Floating Mist + Spectrum:
1. `extractNumericModeValue` rejected `value: 0`, dropping **Floating Mist** (mode id 0 — H70B6 is 0-indexed).
2. The shape-2b 'collect any field' fallback ran even with a real `musicMode` field present, so `autoColor` (on=1/off=0) overwrote **Spectrum** (value 1) in the value-keyed dedupe map.

**Fix:** accept non-negative mode ids (`>= 0`); only run the renamed-field fallback when no preferred `musicMode` field matched.

Also **bumps manifest `Version` 2.7.5.0 → 2.7.7.0** — it was never updated for 2.7.6, so the Stream Deck store kept serving the old build (why the reporter still saw the old version).

New H70B6 regression test (asserts all 10 modes, no `autoColor` leak, correct 0/1 values). 613 unit tests pass, build clean, nox scan passed.