### PR TITLE
fix(toggle): support per-socket toggles on multi-outlet devices (#261)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@elgato/streamdeck": "^2.1.0",
-        "@felixgeelhaar/govee-api-client": "^3.3.7",
+        "@felixgeelhaar/govee-api-client": "^3.3.8",
         "zod": "4.4.3"
       },
       "devDependencies": {
@@ -550,9 +550,9 @@
       }
     },
     "node_modules/@felixgeelhaar/govee-api-client": {
-      "version": "3.3.7",
-      "resolved": "https://registry.npmjs.org/@felixgeelhaar/govee-api-client/-/govee-api-client-3.3.7.tgz",
-      "integrity": "sha512-WBxfrZ3JVfsHcR9JlP2eiTMAvg/xwkU+vNEVycJQwyORmPXOH1+52IrMDwjyCNTP8TEOzcCw/Exvz2leJi+aIg==",
+      "version": "3.3.8",
+      "resolved": "https://registry.npmjs.org/@felixgeelhaar/govee-api-client/-/govee-api-client-3.3.8.tgz",
+      "integrity": "sha512-yCEklImDywAVWuRZfbd98mXPFSYwaa4ALlkqG7xBYT/pBYELE/d+TWGxYlKd0BQSAMrgTiGXP+Wq/HFdDJjAeQ==",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.16.0",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
   },
   "dependencies": {
     "@elgato/streamdeck": "^2.1.0",
-    "@felixgeelhaar/govee-api-client": "^3.3.7",
+    "@felixgeelhaar/govee-api-client": "^3.3.8",
     "zod": "4.4.3"
   },
   "overrides": {

--- a/src/backend/actions/shared/validation.ts
+++ b/src/backend/actions/shared/validation.ts
@@ -57,6 +57,41 @@ export const VALID_TOGGLE_INSTANCES = new Set([
 ]);
 
 /**
+ * Indexed per-socket / per-zone toggle instances exposed by multi-outlet and
+ * multi-zone devices, e.g. `socketToggle1` / `socketToggle2` on the HS5089
+ * Smart Outlet Extender. These are not known ahead of time (the count varies
+ * by device), so they are matched by shape rather than enumerated: a non-empty
+ * alphabetic prefix, the literal `Toggle`, and a trailing index. They all map
+ * to `devices.capabilities.toggle` with the instance name as discriminator.
+ */
+const INDEXED_TOGGLE_INSTANCE = /^[a-zA-Z]+Toggle\d+$/;
+
+/**
+ * Whether a toggle instance name is safe to forward to the Govee API. Accepts
+ * the known named instances and any indexed per-socket/zone toggle; everything
+ * else is rejected to stop arbitrary command forwarding.
+ */
+export function isValidToggleInstance(instance: string): boolean {
+  return (
+    VALID_TOGGLE_INSTANCES.has(instance) ||
+    INDEXED_TOGGLE_INSTANCE.test(instance)
+  );
+}
+
+/**
+ * Human-friendly label for an indexed toggle instance with no curated name,
+ * e.g. `socketToggle1` → `Socket 1`. Returns the raw instance unchanged when
+ * it is not an indexed toggle, so callers can fall back to it directly.
+ */
+export function toggleInstanceFallbackLabel(instance: string): string {
+  const match = /^([a-zA-Z]+)Toggle(\d+)$/.exec(instance);
+  if (!match) return instance;
+  const [, prefix, index] = match;
+  const label = prefix.charAt(0).toUpperCase() + prefix.slice(1);
+  return `${label} ${index}`;
+}
+
+/**
  * Parse and validate a JSON feature setting string.
  * Returns null if the string is malformed or missing required fields.
  */

--- a/src/backend/infrastructure/repositories/GoveeLightRepository.ts
+++ b/src/backend/infrastructure/repositories/GoveeLightRepository.ts
@@ -26,7 +26,8 @@ import { MusicModeConfig } from "../../domain/value-objects/MusicModeConfig";
 import {
   isIgnorableLiveStateError,
   isValidationError,
-  VALID_TOGGLE_INSTANCES,
+  isValidToggleInstance,
+  toggleInstanceFallbackLabel,
 } from "../../actions/shared/validation";
 import { safeGetColorTemperature } from "../utils/deviceStateUtils";
 import { parseMusicModeOptions } from "../mappers/music-mode-options";
@@ -782,7 +783,7 @@ export class GoveeLightRepository implements ILightRepository {
     instance: string,
     enabled: boolean,
   ): Promise<void> {
-    if (!VALID_TOGGLE_INSTANCES.has(instance)) {
+    if (!isValidToggleInstance(instance)) {
       throw new Error(`Rejected unknown toggle instance: ${instance}`);
     }
     try {
@@ -874,7 +875,9 @@ export class GoveeLightRepository implements ILightRepository {
       return device.capabilities
         .filter((cap) => cap.type.includes("toggle"))
         .map((cap) => ({
-          name: TOGGLE_LABELS[cap.instance] ?? cap.instance,
+          name:
+            TOGGLE_LABELS[cap.instance] ??
+            toggleInstanceFallbackLabel(cap.instance),
           instance: cap.instance,
         }));
     } catch (error) {

--- a/test/backend/actions/shared/validation.test.ts
+++ b/test/backend/actions/shared/validation.test.ts
@@ -4,6 +4,7 @@ import {
   isIgnorableLiveStateError,
   isValidApiKeyFormat,
   isValidationError,
+  isValidToggleInstance,
   parseFeatureSetting,
   VALID_TOGGLE_INSTANCES,
 } from "../../../../src/backend/actions/shared/validation";
@@ -81,6 +82,30 @@ describe("validation helpers", () => {
 
     it("rejects unknown instances to stop arbitrary command forwarding", () => {
       expect(VALID_TOGGLE_INSTANCES.has("arbitraryCommand")).toBe(false);
+    });
+  });
+
+  describe("isValidToggleInstance", () => {
+    it("accepts the named lighting toggle instances", () => {
+      expect(isValidToggleInstance("nightlightToggle")).toBe(true);
+      expect(isValidToggleInstance("gradientToggle")).toBe(true);
+      expect(isValidToggleInstance("dreamViewToggle")).toBe(true);
+      expect(isValidToggleInstance("sceneStageToggle")).toBe(true);
+    });
+
+    it("accepts indexed per-socket toggle instances (multi-outlet devices)", () => {
+      // HS5089 Smart Outlet Extender exposes socketToggle1, socketToggle2, …
+      expect(isValidToggleInstance("socketToggle1")).toBe(true);
+      expect(isValidToggleInstance("socketToggle2")).toBe(true);
+      expect(isValidToggleInstance("socketToggle12")).toBe(true);
+    });
+
+    it("rejects arbitrary, non-toggle instances", () => {
+      expect(isValidToggleInstance("arbitraryCommand")).toBe(false);
+      expect(isValidToggleInstance("turn")).toBe(false);
+      expect(isValidToggleInstance("brightness")).toBe(false);
+      // A bare "Toggle" with no prefix is not a real Govee instance.
+      expect(isValidToggleInstance("Toggle1")).toBe(false);
     });
   });
 

--- a/test/infrastructure/repositories/GoveeLightRepository.test.ts
+++ b/test/infrastructure/repositories/GoveeLightRepository.test.ts
@@ -4,6 +4,8 @@ import { GoveeLightRepository } from "../../../src/backend/infrastructure/reposi
 const clientMocks = vi.hoisted(() => ({
   getDiyScenes: vi.fn(),
   setDiyScene: vi.fn(),
+  getControllableDevices: vi.fn(),
+  sendCommand: vi.fn(),
 }));
 
 vi.mock("@felixgeelhaar/govee-api-client", () => {
@@ -64,6 +66,8 @@ vi.mock("@felixgeelhaar/govee-api-client", () => {
   class MockGoveeClient {
     getDiyScenes = clientMocks.getDiyScenes;
     setDiyScene = clientMocks.setDiyScene;
+    getControllableDevices = clientMocks.getControllableDevices;
+    sendCommand = clientMocks.sendCommand;
   }
 
   return {
@@ -120,5 +124,99 @@ describe("GoveeLightRepository DIY scene support", () => {
       light.model,
       expect.objectContaining({ id: 456, paramId: 456, name: "DIY Sunset" }),
     );
+  });
+});
+
+describe("GoveeLightRepository multi-outlet socket toggles", () => {
+  // HS5089 Smart Outlet Extender: each socket is its own toggle capability
+  // instance (socketToggle1, socketToggle2, …). Regression coverage for #261,
+  // where these surfaced in the picker but every press was rejected.
+  const outlet = {
+    deviceId: "AA:BB:CC:DD:EE:FF:00:11",
+    model: "HS5089",
+    name: "Smart Outlet Extender",
+    updateState: vi.fn(),
+  } as any;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("labels indexed socket toggles as 'Socket N' in getToggleFeatures", async () => {
+    clientMocks.getControllableDevices.mockResolvedValue([
+      {
+        deviceId: outlet.deviceId,
+        model: outlet.model,
+        capabilities: [
+          { type: "devices.capabilities.toggle", instance: "socketToggle1" },
+          { type: "devices.capabilities.toggle", instance: "socketToggle2" },
+          { type: "devices.capabilities.on_off", instance: "powerSwitch" },
+        ],
+      },
+    ]);
+
+    const repository = new GoveeLightRepository("api-key");
+    const features = await repository.getToggleFeatures(
+      `light:${outlet.deviceId}|${outlet.model}`,
+    );
+
+    expect(features).toEqual([
+      { name: "Socket 1", instance: "socketToggle1" },
+      { name: "Socket 2", instance: "socketToggle2" },
+    ]);
+  });
+
+  it("forwards a socketToggle command to the API client instead of rejecting it", async () => {
+    clientMocks.sendCommand.mockResolvedValue(undefined);
+
+    const repository = new GoveeLightRepository("api-key");
+    await repository.toggleRaw(outlet, "socketToggle1", false);
+
+    expect(clientMocks.sendCommand).toHaveBeenCalledWith(
+      outlet.deviceId,
+      outlet.model,
+      expect.objectContaining({ name: "socketToggle1", value: 0 }),
+    );
+  });
+
+  it("still rejects arbitrary, non-toggle instances", async () => {
+    const repository = new GoveeLightRepository("api-key");
+
+    await expect(
+      repository.toggleRaw(outlet, "arbitraryCommand", true),
+    ).rejects.toThrow("Rejected unknown toggle instance: arbitraryCommand");
+    expect(clientMocks.sendCommand).not.toHaveBeenCalled();
+  });
+
+  it("invariant: every feature the picker offers is one toggleRaw accepts", async () => {
+    // The #261 bug was a contract break between the two halves of the action:
+    // getToggleFeatures surfaced socketToggle1, but toggleRaw rejected it, so
+    // the press silently no-op'd. Lock the contract: anything the picker shows
+    // must be forwardable.
+    clientMocks.getControllableDevices.mockResolvedValue([
+      {
+        deviceId: outlet.deviceId,
+        model: outlet.model,
+        capabilities: [
+          { type: "devices.capabilities.toggle", instance: "nightlightToggle" },
+          { type: "devices.capabilities.toggle", instance: "socketToggle1" },
+          { type: "devices.capabilities.toggle", instance: "socketToggle2" },
+        ],
+      },
+    ]);
+    clientMocks.sendCommand.mockResolvedValue(undefined);
+
+    const repository = new GoveeLightRepository("api-key");
+    const features = await repository.getToggleFeatures(
+      `light:${outlet.deviceId}|${outlet.model}`,
+    );
+    expect(features.length).toBeGreaterThan(0);
+
+    for (const feature of features) {
+      await expect(
+        repository.toggleRaw(outlet, feature.instance, true),
+      ).resolves.not.toThrow();
+    }
+    expect(clientMocks.sendCommand).toHaveBeenCalledTimes(features.length);
   });
 });


### PR DESCRIPTION
Fixes #261.

## Problem

On the HS5089 Smart Outlet Extender, the **Feature Toggle** action lists each socket (`socketToggle1`, `socketToggle2`) but every press silently fails — the socket never switches, while nightlight and the Govee app work fine.

Two breaks, one per repo:

1. **Plugin (this PR):** `toggleRaw` guarded against a fixed `VALID_TOGGLE_INSTANCES` set of four lighting toggles. Socket instances — surfaced by `getToggleFeatures` from the device's own capability list — were rejected before reaching the API. The picker also showed the raw `socketToggle1` instead of a friendly label.
2. **Client (`govee-api-client` 3.3.8, shipped):** `inferCapabilityType` matched toggles with `endsWith('Toggle')`, which misses the trailing digit in `socketToggle1`, mis-routing the command to an invalid capability type that Govee rejects.

Both were needed; the client fix is published as 3.3.8 (felixgeelhaar/govee-api-client#36).

## Changes

- `isValidToggleInstance()` replaces the `Set.has` guard — accepts the named instances plus any indexed `*Toggle<n>` shape. **Generic across devices and socket counts**, not an HS5089 special-case.
- `toggleInstanceFallbackLabel()` renders indexed instances as `Socket 1`, `Socket 2`, … in the picker.
- Bump `@felixgeelhaar/govee-api-client` to `^3.3.8`.
- Validation helpers live in the shared layer; the repository consumes them — DDD layering preserved.

## Tests (TDD red→green)

- `isValidToggleInstance` — named + indexed accepted, arbitrary/`turn`/bare-`Toggle1` rejected.
- Repository: `getToggleFeatures` labels sockets `Socket N`; `toggleRaw` forwards `socketToggle1`; arbitrary instances still throw.
- **Contract invariant:** every feature the picker offers is one `toggleRaw` accepts — locks the exact gap that caused #261.
- Full suite: 620 unit tests passing; type-check + lint + build clean against 3.3.8.

## Done

- [x] `govee-api-client` 3.3.8 published
- [x] Client dependency bumped to `^3.3.8`

## Hardware dogfooding

I don't have an HS5089 to verify on real hardware. The fix is covered by unit tests + the picker/forward contract invariant, but **end-to-end confirmation should come from the reporter** (or a maintainer with the device) — toggle each socket from the key and confirm it switches. Flagging honestly rather than claiming hardware-verified.