### PR TITLE
chore(release): plugin 2.7.8 — per-socket toggle support (#261)

### DIFF
--- a/com.felixgeelhaar.govee-light-management.sdPlugin/manifest.json
+++ b/com.felixgeelhaar.govee-light-management.sdPlugin/manifest.json
@@ -1,6 +1,6 @@
 {
   "Name": "Govee Light Management",
-  "Version": "2.7.7.0",
+  "Version": "2.7.8.0",
   "Author": "Felix Geelhaar",
   "URL": "https://github.com/felixgeelhaar/govee-light-management",
   "SupportURL": "https://github.com/felixgeelhaar/govee-light-management/issues",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "govee-light-management",
-  "version": "2.7.7",
+  "version": "2.7.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "govee-light-management",
-      "version": "2.7.7",
+      "version": "2.7.8",
       "license": "MIT",
       "dependencies": {
         "@elgato/streamdeck": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "govee-light-management",
-  "version": "2.7.7",
+  "version": "2.7.8",
   "description": "Enterprise-grade Stream Deck plugin for managing Govee lights with advanced group functionality",
   "main": "com.felixgeelhaar.govee-light-management.sdPlugin/bin/plugin.js",
   "scripts": {


### PR DESCRIPTION
Release bump for the #261 fix (merged in #262).

- `package.json` + `manifest.json` → 2.7.8 / 2.7.8.0
- Bundles `govee-api-client` 3.3.8 (indexed-toggle routing)

Per-socket toggles on multi-outlet devices (HS5089 Smart Outlet Extender) now work end-to-end: the picker offers `Socket 1` / `Socket 2`, and presses reach the device.

Tag `v2.7.8` after merge to trigger the release workflow.