### PR TITLE
fix(music-mode): trigger Floating Mist (mode id 0) on H70B6

### DIFF
--- a/com.felixgeelhaar.govee-light-management.sdPlugin/manifest.json
+++ b/com.felixgeelhaar.govee-light-management.sdPlugin/manifest.json
@@ -1,6 +1,6 @@
 {
   "Name": "Govee Light Management",
-  "Version": "2.7.8.0",
+  "Version": "2.7.9.0",
   "Author": "Felix Geelhaar",
   "URL": "https://github.com/felixgeelhaar/govee-light-management",
   "SupportURL": "https://github.com/felixgeelhaar/govee-light-management/issues",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "govee-light-management",
-  "version": "2.7.8",
+  "version": "2.7.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "govee-light-management",
-      "version": "2.7.8",
+      "version": "2.7.9",
       "license": "MIT",
       "dependencies": {
         "@elgato/streamdeck": "^2.1.0",
-        "@felixgeelhaar/govee-api-client": "^3.3.8",
+        "@felixgeelhaar/govee-api-client": "^3.3.9",
         "zod": "4.4.3"
       },
       "devDependencies": {
@@ -550,9 +550,9 @@
       }
     },
     "node_modules/@felixgeelhaar/govee-api-client": {
-      "version": "3.3.8",
-      "resolved": "https://registry.npmjs.org/@felixgeelhaar/govee-api-client/-/govee-api-client-3.3.8.tgz",
-      "integrity": "sha512-yCEklImDywAVWuRZfbd98mXPFSYwaa4ALlkqG7xBYT/pBYELE/d+TWGxYlKd0BQSAMrgTiGXP+Wq/HFdDJjAeQ==",
+      "version": "3.3.9",
+      "resolved": "https://registry.npmjs.org/@felixgeelhaar/govee-api-client/-/govee-api-client-3.3.9.tgz",
+      "integrity": "sha512-S7BTUNfu5S9FCnEKeXtb8d6PFGujv/LsN7+hF4vM62e7IYf8NeSXnhu/ARVzWntBUhjKh0yHqWwU4A3+D89jmA==",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.16.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "govee-light-management",
-  "version": "2.7.8",
+  "version": "2.7.9",
   "description": "Enterprise-grade Stream Deck plugin for managing Govee lights with advanced group functionality",
   "main": "com.felixgeelhaar.govee-light-management.sdPlugin/bin/plugin.js",
   "scripts": {
@@ -62,7 +62,7 @@
   },
   "dependencies": {
     "@elgato/streamdeck": "^2.1.0",
-    "@felixgeelhaar/govee-api-client": "^3.3.8",
+    "@felixgeelhaar/govee-api-client": "^3.3.9",
     "zod": "4.4.3"
   },
   "overrides": {


### PR DESCRIPTION
## Summary

Bumps `@felixgeelhaar/govee-api-client` to **3.3.9**, which accepts music mode id **0**.

Closes #250. The **Curtain Lights Pro (H70B6)** is zero-indexed and exposes `Floating Mist` as mode id `0`. The 2.7.7 parser fix made it *appear* in the dropdown, but on key press the client rejected `0` (`modeId <= 0`) and threw before the command reached the device — so the button silently did nothing. Spectrum (id 1) was unaffected, matching the reporter's exact symptom.

Root cause + regression test live in client: felixgeelhaar/govee-api-client#38 (released as 3.3.9).

## Changes
- Dep: `@felixgeelhaar/govee-api-client` `3.3.8 → 3.3.9` (+ lockfile)
- Version: package `2.7.9`, manifest `Version` `2.7.9.0` (manifest bump matters — 2.7.6 didn't and the store kept serving the old build)

## Checks
- lint clean, 620 tests pass, `npm run build` OK, `streamdeck validate` successful