### PR TITLE
fix(toggle): validate toggle writes against device capabilities (#270)

### DIFF
--- a/src/backend/actions/shared/validation.ts
+++ b/src/backend/actions/shared/validation.ts
@@ -57,38 +57,50 @@ export const VALID_TOGGLE_INSTANCES = new Set([
 ]);
 
 /**
- * Indexed per-socket / per-zone toggle instances exposed by multi-outlet and
- * multi-zone devices, e.g. `socketToggle1` / `socketToggle2` on the HS5089
- * Smart Outlet Extender. These are not known ahead of time (the count varies
- * by device), so they are matched by shape rather than enumerated: a non-empty
- * alphabetic prefix, the literal `Toggle`, and a trailing index. They all map
- * to `devices.capabilities.toggle` with the instance name as discriminator.
+ * Shape of a Govee toggle-capability instance. Govee names every toggle in
+ * camelCase ending in `Toggle`, optionally with a trailing index for
+ * per-socket / per-zone devices, e.g. `nightlightToggle`, `socketToggle1`
+ * (HS5089 Smart Outlet Extender), `rippleLightToggle` / `sideLightToggle` /
+ * `bottomLightToggle` (H60B0 Uplighter Floor Lamp).
+ *
+ * Instances are sourced from each device's own advertised `toggle`
+ * capabilities, so the count and names are not known ahead of time. Matching
+ * by shape — rather than a fixed enumeration — lets every toggle a device
+ * reports work, including ones Govee adds later, while still rejecting
+ * arbitrary command names. Requiring a leading lowercase letter rejects a
+ * bare `Toggle1` (no real instance prefix).
  */
-const INDEXED_TOGGLE_INSTANCE = /^[a-zA-Z]+Toggle\d+$/;
+const TOGGLE_INSTANCE_SHAPE = /^[a-z][a-zA-Z]*Toggle\d*$/;
 
 /**
  * Whether a toggle instance name is safe to forward to the Govee API. Accepts
- * the known named instances and any indexed per-socket/zone toggle; everything
- * else is rejected to stop arbitrary command forwarding.
+ * any device-advertised toggle instance matching the Govee `*Toggle` shape;
+ * everything else is rejected to stop arbitrary command forwarding.
  */
 export function isValidToggleInstance(instance: string): boolean {
   return (
-    VALID_TOGGLE_INSTANCES.has(instance) ||
-    INDEXED_TOGGLE_INSTANCE.test(instance)
+    VALID_TOGGLE_INSTANCES.has(instance) || TOGGLE_INSTANCE_SHAPE.test(instance)
   );
 }
 
 /**
- * Human-friendly label for an indexed toggle instance with no curated name,
- * e.g. `socketToggle1` → `Socket 1`. Returns the raw instance unchanged when
- * it is not an indexed toggle, so callers can fall back to it directly.
+ * Human-friendly label for a toggle instance with no curated name, derived
+ * generically from the instance shape so any device-advertised toggle reads
+ * well in the picker:
+ *   `socketToggle1`     → `Socket 1`
+ *   `rippleLightToggle` → `Ripple Light`
+ *   `bottomLightToggle` → `Bottom Light`
+ * Returns the raw instance unchanged when it is not a `*Toggle` instance, so
+ * callers can fall back to it directly.
  */
 export function toggleInstanceFallbackLabel(instance: string): string {
-  const match = /^([a-zA-Z]+)Toggle(\d+)$/.exec(instance);
+  const match = /^([a-z][a-zA-Z]*)Toggle(\d*)$/.exec(instance);
   if (!match) return instance;
   const [, prefix, index] = match;
-  const label = prefix.charAt(0).toUpperCase() + prefix.slice(1);
-  return `${label} ${index}`;
+  const words = prefix
+    .replace(/([a-z])([A-Z])/g, "$1 $2")
+    .replace(/^./, (c) => c.toUpperCase());
+  return index ? `${words} ${index}` : words;
 }
 
 /**

--- a/src/backend/infrastructure/repositories/GoveeLightRepository.ts
+++ b/src/backend/infrastructure/repositories/GoveeLightRepository.ts
@@ -38,6 +38,20 @@ export class GoveeLightRepository implements ILightRepository {
   private client: GoveeClient;
   private readonly apiKey: string;
 
+  /**
+   * Short-lived cache of the controllable-device list. The device capability
+   * list is the authoritative contract for which toggles a device supports
+   * (see `getDeviceToggleInstances` / `toggleRaw`), but fetching it is a full
+   * API round-trip. Cache it briefly so validating a toggle press doesn't add
+   * latency or burn rate-limit budget on every key press. A device's set of
+   * capabilities does not change within a session, so a short TTL is safe.
+   */
+  private controllableDevicesCache?: {
+    devices: GoveeDevice[];
+    expires: number;
+  };
+  private static readonly DEVICE_CACHE_TTL_MS = 60_000;
+
   constructor(apiKey: string, enableRetries = true) {
     this.apiKey = apiKey;
     this.client = new GoveeClient({
@@ -783,9 +797,7 @@ export class GoveeLightRepository implements ILightRepository {
     instance: string,
     enabled: boolean,
   ): Promise<void> {
-    if (!isValidToggleInstance(instance)) {
-      throw new Error(`Rejected unknown toggle instance: ${instance}`);
-    }
+    await this.assertToggleSupported(light, instance);
     try {
       const command = {
         name: instance,
@@ -859,10 +871,7 @@ export class GoveeLightRepository implements ILightRepository {
       const [deviceId, model] = cleanId.split("|");
       if (!deviceId || !model) return [];
 
-      const devices = await this.client.getControllableDevices();
-      const device = devices.find(
-        (d) => d.deviceId === deviceId && d.model === model,
-      );
+      const device = await this.findControllableDevice(deviceId, model);
       if (!device) return [];
 
       const TOGGLE_LABELS: Record<string, string> = {
@@ -883,6 +892,100 @@ export class GoveeLightRepository implements ILightRepository {
     } catch (error) {
       streamDeck.logger.error("Failed to get toggle features:", error);
       return [];
+    }
+  }
+
+  /**
+   * Controllable-device list with a short TTL cache. The same list backs the
+   * Property Inspector's toggle picker (`getToggleFeatures`) and the send-side
+   * validation (`assertToggleSupported`), so caching keeps the two halves
+   * agreeing on one source of truth without an API call per toggle press.
+   */
+  private async getControllableDevicesCached(): Promise<GoveeDevice[]> {
+    const now = Date.now();
+    const cached = this.controllableDevicesCache;
+    if (cached && cached.expires > now) {
+      return cached.devices;
+    }
+    const devices = await this.client.getControllableDevices();
+    if (Array.isArray(devices)) {
+      this.controllableDevicesCache = {
+        devices,
+        expires: now + GoveeLightRepository.DEVICE_CACHE_TTL_MS,
+      };
+      return devices;
+    }
+    // Defensive: never cache a non-array; let callers treat as "unavailable".
+    return [];
+  }
+
+  private async findControllableDevice(
+    deviceId: string,
+    model: string,
+  ): Promise<GoveeDevice | undefined> {
+    const devices = await this.getControllableDevicesCached();
+    return devices.find((d) => d.deviceId === deviceId && d.model === model);
+  }
+
+  /**
+   * Set of toggle instances the device actually advertises in its capability
+   * list — the authoritative list of what the user can toggle. Returns
+   * `undefined` when the device can't be located (offline, not yet discovered,
+   * or the list couldn't be fetched), signalling the caller to fall back to a
+   * conservative shape check rather than block a possibly-valid command.
+   */
+  private async getDeviceToggleInstances(
+    light: Light,
+  ): Promise<Set<string> | undefined> {
+    const device = await this.findControllableDevice(
+      light.deviceId,
+      light.model,
+    );
+    if (!device) return undefined;
+    return new Set(
+      device.capabilities
+        .filter((cap) => cap.type.includes("toggle"))
+        .map((cap) => cap.instance),
+    );
+  }
+
+  /**
+   * Guard a toggle write against what the device advertises. Validating against
+   * the device's own capability list (the same source the picker reads) makes
+   * the picker↔send contract structural: anything offered is forwardable, and
+   * anything the device doesn't support is rejected — by model, not a hardcoded
+   * name list, so new Govee toggles work the moment a device reports them
+   * (issue #270: H60B0 ripple/side/bottom light toggles).
+   *
+   * Falls back to the `*Toggle` shape check only when the capability list is
+   * unavailable, so a transient discovery failure degrades to a conservative
+   * guard instead of breaking a valid toggle.
+   */
+  private async assertToggleSupported(
+    light: Light,
+    instance: string,
+  ): Promise<void> {
+    let advertised: Set<string> | undefined;
+    try {
+      advertised = await this.getDeviceToggleInstances(light);
+    } catch (error) {
+      streamDeck.logger.warn(
+        `Could not load capabilities to validate toggle ${instance} for ${light.name}; falling back to shape check:`,
+        error,
+      );
+    }
+
+    if (advertised) {
+      if (!advertised.has(instance)) {
+        throw new Error(
+          `Device ${light.model} does not advertise toggle instance: ${instance}`,
+        );
+      }
+      return;
+    }
+
+    if (!isValidToggleInstance(instance)) {
+      throw new Error(`Rejected unknown toggle instance: ${instance}`);
     }
   }
 

--- a/test/backend/actions/shared/validation.test.ts
+++ b/test/backend/actions/shared/validation.test.ts
@@ -6,6 +6,7 @@ import {
   isValidationError,
   isValidToggleInstance,
   parseFeatureSetting,
+  toggleInstanceFallbackLabel,
   VALID_TOGGLE_INSTANCES,
 } from "../../../../src/backend/actions/shared/validation";
 
@@ -100,12 +101,43 @@ describe("validation helpers", () => {
       expect(isValidToggleInstance("socketToggle12")).toBe(true);
     });
 
+    it("accepts named lighting toggles advertised by the device (issue #270)", () => {
+      // H60B0 Uplighter Floor Lamp exposes rippleLightToggle, sideLightToggle,
+      // bottomLightToggle. These have no trailing index and aren't in the
+      // curated set, but the device advertises them so they must forward.
+      expect(isValidToggleInstance("rippleLightToggle")).toBe(true);
+      expect(isValidToggleInstance("sideLightToggle")).toBe(true);
+      expect(isValidToggleInstance("bottomLightToggle")).toBe(true);
+    });
+
     it("rejects arbitrary, non-toggle instances", () => {
       expect(isValidToggleInstance("arbitraryCommand")).toBe(false);
       expect(isValidToggleInstance("turn")).toBe(false);
       expect(isValidToggleInstance("brightness")).toBe(false);
       // A bare "Toggle" with no prefix is not a real Govee instance.
       expect(isValidToggleInstance("Toggle1")).toBe(false);
+      expect(isValidToggleInstance("Toggle")).toBe(false);
+    });
+  });
+
+  describe("toggleInstanceFallbackLabel", () => {
+    it("splits camelCase lighting toggles into readable labels (issue #270)", () => {
+      expect(toggleInstanceFallbackLabel("rippleLightToggle")).toBe(
+        "Ripple Light",
+      );
+      expect(toggleInstanceFallbackLabel("sideLightToggle")).toBe("Side Light");
+      expect(toggleInstanceFallbackLabel("bottomLightToggle")).toBe(
+        "Bottom Light",
+      );
+    });
+
+    it("labels indexed per-socket toggles", () => {
+      expect(toggleInstanceFallbackLabel("socketToggle1")).toBe("Socket 1");
+      expect(toggleInstanceFallbackLabel("socketToggle12")).toBe("Socket 12");
+    });
+
+    it("returns non-toggle instances unchanged", () => {
+      expect(toggleInstanceFallbackLabel("brightness")).toBe("brightness");
     });
   });
 

--- a/test/infrastructure/repositories/GoveeLightRepository.test.ts
+++ b/test/infrastructure/repositories/GoveeLightRepository.test.ts
@@ -1,6 +1,21 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { GoveeLightRepository } from "../../../src/backend/infrastructure/repositories/GoveeLightRepository";
 
+// The repository imports the Stream Deck SDK as a default export
+// (`import streamDeck from "@elgato/streamdeck"`). The global test setup mocks
+// only the named export, so provide a default with a logger for the code paths
+// that log (e.g. the toggle-validation fallback warning).
+vi.mock("@elgato/streamdeck", () => {
+  const logger = {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+    setLevel: vi.fn(),
+  };
+  return { default: { logger }, streamDeck: { logger } };
+});
+
 const clientMocks = vi.hoisted(() => ({
   getDiyScenes: vi.fn(),
   setDiyScene: vi.fn(),
@@ -179,13 +194,59 @@ describe("GoveeLightRepository multi-outlet socket toggles", () => {
     );
   });
 
-  it("still rejects arbitrary, non-toggle instances", async () => {
+  it("rejects an instance the device does not advertise (authoritative)", async () => {
+    // When the capability list is available, validation is by-model: the
+    // device advertises only socketToggle1/2, so anything else is rejected —
+    // even something with a valid toggle shape.
+    clientMocks.getControllableDevices.mockResolvedValue([
+      {
+        deviceId: outlet.deviceId,
+        model: outlet.model,
+        capabilities: [
+          { type: "devices.capabilities.toggle", instance: "socketToggle1" },
+          { type: "devices.capabilities.toggle", instance: "socketToggle2" },
+        ],
+      },
+    ]);
+
+    const repository = new GoveeLightRepository("api-key");
+
+    await expect(
+      repository.toggleRaw(outlet, "arbitraryCommand", true),
+    ).rejects.toThrow(
+      `Device ${outlet.model} does not advertise toggle instance: arbitraryCommand`,
+    );
+    // A shaped-but-unsupported instance is also rejected by-model.
+    await expect(
+      repository.toggleRaw(outlet, "ghostToggle", true),
+    ).rejects.toThrow(
+      `Device ${outlet.model} does not advertise toggle instance: ghostToggle`,
+    );
+    expect(clientMocks.sendCommand).not.toHaveBeenCalled();
+  });
+
+  it("falls back to the shape guard when the device list is unavailable", async () => {
+    // Discovery failed / device not yet known: no capability list to validate
+    // against. Degrade to the conservative *Toggle shape check rather than
+    // block a possibly-valid press — a shaped instance forwards, garbage does not.
+    clientMocks.getControllableDevices.mockRejectedValue(
+      new Error("network down"),
+    );
+    clientMocks.sendCommand.mockResolvedValue(undefined);
+
     const repository = new GoveeLightRepository("api-key");
 
     await expect(
       repository.toggleRaw(outlet, "arbitraryCommand", true),
     ).rejects.toThrow("Rejected unknown toggle instance: arbitraryCommand");
     expect(clientMocks.sendCommand).not.toHaveBeenCalled();
+
+    await repository.toggleRaw(outlet, "nightlightToggle", true);
+    expect(clientMocks.sendCommand).toHaveBeenCalledWith(
+      outlet.deviceId,
+      outlet.model,
+      expect.objectContaining({ name: "nightlightToggle", value: 1 }),
+    );
   });
 
   it("invariant: every feature the picker offers is one toggleRaw accepts", async () => {
@@ -218,5 +279,61 @@ describe("GoveeLightRepository multi-outlet socket toggles", () => {
       ).resolves.not.toThrow();
     }
     expect(clientMocks.sendCommand).toHaveBeenCalledTimes(features.length);
+  });
+});
+
+describe("GoveeLightRepository named lighting toggles (issue #270)", () => {
+  // H60B0 Uplighter Floor Lamp advertises rippleLightToggle, sideLightToggle,
+  // bottomLightToggle — named (non-indexed) toggles outside the old curated
+  // set. They surfaced in the picker but every press was rejected before the
+  // by-model validation. Lock the contract for this device class too.
+  const lamp = {
+    deviceId: "11:22:33:44:55:66:77:88",
+    model: "H60B0",
+    name: "Uplighter Floor Lamp",
+    updateState: vi.fn(),
+  } as any;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("forwards every advertised light toggle the picker offers", async () => {
+    clientMocks.getControllableDevices.mockResolvedValue([
+      {
+        deviceId: lamp.deviceId,
+        model: lamp.model,
+        capabilities: [
+          { type: "devices.capabilities.toggle", instance: "rippleLightToggle" },
+          { type: "devices.capabilities.toggle", instance: "sideLightToggle" },
+          { type: "devices.capabilities.toggle", instance: "bottomLightToggle" },
+          { type: "devices.capabilities.on_off", instance: "powerSwitch" },
+        ],
+      },
+    ]);
+    clientMocks.sendCommand.mockResolvedValue(undefined);
+
+    const repository = new GoveeLightRepository("api-key");
+
+    const features = await repository.getToggleFeatures(
+      `light:${lamp.deviceId}|${lamp.model}`,
+    );
+    expect(features).toEqual([
+      { name: "Ripple Light", instance: "rippleLightToggle" },
+      { name: "Side Light", instance: "sideLightToggle" },
+      { name: "Bottom Light", instance: "bottomLightToggle" },
+    ]);
+
+    for (const feature of features) {
+      await expect(
+        repository.toggleRaw(lamp, feature.instance, true),
+      ).resolves.not.toThrow();
+    }
+    expect(clientMocks.sendCommand).toHaveBeenCalledTimes(features.length);
+    expect(clientMocks.sendCommand).toHaveBeenCalledWith(
+      lamp.deviceId,
+      lamp.model,
+      expect.objectContaining({ name: "rippleLightToggle", value: 1 }),
+    );
   });
 });


### PR DESCRIPTION
## Problem

Fixes #270. H60B0 Uplighter Floor Lamp toggle features (`rippleLightToggle`, `sideLightToggle`, `bottomLightToggle`) showed in the picker but On/Off/Toggle commands silently no-opped.

## Root cause

Same contract break as #261. Two halves of the toggle action disagreed on which instances are valid:

- **Picker** (`getToggleFeatures`): generic — lists any `toggle` capability the device advertises.
- **Send** (`toggleRaw`): gated on `isValidToggleInstance` — a hardcoded name set plus indexed `*Toggle<digit>`. The H60B0 named toggles matched neither, so every send was rejected before reaching the API.

## Fix — validate against the device, not a name list

`toggleRaw` now validates the instance against the device's own advertised toggle capabilities — **the same source the picker reads**. This makes the picker↔send contract structural: anything offered is forwardable; anything the device doesn't support is rejected by model. New Govee toggles work the moment a device reports them — no code change per device.

Details:
- Controllable-device list cached briefly (60s TTL) so validation adds no API round-trip per key press; the picker query warms it.
- When the capability list can't be fetched (offline / not yet discovered), validation degrades to a conservative `*Toggle` shape guard rather than block a valid press.
- Picker labels derive generically from the instance shape (`rippleLightToggle` → `Ripple Light`).

## Tests

- By-model rejection (shaped-but-unsupported instance rejected).
- Shape-guard fallback when device discovery fails.
- H60B0 end-to-end picker→send invariant (every offered toggle forwards).
- Existing #261 socket-toggle invariant retained.

Full suite: 626 passed. Type-check clean.