### PR TITLE
chore(release): plugin 2.7.10

### DIFF
--- a/com.felixgeelhaar.govee-light-management.sdPlugin/manifest.json
+++ b/com.felixgeelhaar.govee-light-management.sdPlugin/manifest.json
@@ -1,6 +1,6 @@
 {
   "Name": "Govee Light Management",
-  "Version": "2.7.9.0",
+  "Version": "2.7.10.0",
   "Author": "Felix Geelhaar",
   "URL": "https://github.com/felixgeelhaar/govee-light-management",
   "SupportURL": "https://github.com/felixgeelhaar/govee-light-management/issues",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "govee-light-management",
-  "version": "2.7.9",
+  "version": "2.7.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "govee-light-management",
-      "version": "2.7.9",
+      "version": "2.7.10",
       "license": "MIT",
       "dependencies": {
         "@elgato/streamdeck": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "govee-light-management",
-  "version": "2.7.9",
+  "version": "2.7.10",
   "description": "Enterprise-grade Stream Deck plugin for managing Govee lights with advanced group functionality",
   "main": "com.felixgeelhaar.govee-light-management.sdPlugin/bin/plugin.js",
   "scripts": {


### PR DESCRIPTION
Release v2.7.10.

## Included
- fix(toggle): H60B0 Uplighter Floor Lamp toggle features (#270) — `rippleLightToggle`, `sideLightToggle`, `bottomLightToggle` now apply. Toggle writes are validated against each device's advertised capabilities instead of a hardcoded name list, so any device-advertised toggle forwards.

## Version bump
- package.json / package-lock.json: 2.7.9 → 2.7.10
- manifest.json: 2.7.9.0 → 2.7.10.0

Tag `v2.7.10` pushed after merge triggers the Release workflow (build, pack, publish .streamDeckPlugin).