### PR TITLE
ci: test on a single Node version (20) matching Elgato's runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,24 +26,23 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # Quick validation on Linux with multiple Node versions
+  # Quick validation on the single Node version Stream Deck runs plugins on.
+  # Elgato's CLI validator currently pins the runtime to Node 20 (manifest
+  # Nodejs.Version); Node 24 is documented but not yet accepted by the packer.
+  # We track the validator-supported version and test only that — other
+  # versions add no signal for a plugin that always runs on Elgato's runtime.
   test:
-    name: Test (Node ${{ matrix.node-version }})
+    name: Test (Node 20)
     runs-on: ubuntu-latest
-
-    strategy:
-      fail-fast: false
-      matrix:
-        node-version: [20, 22]
 
     steps:
       - name: Checkout code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      - name: Setup Node.js ${{ matrix.node-version }}
+      - name: Setup Node.js 20
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: "20"
           cache: "npm" # ✅ Cache npm dependencies
 
       - name: Install dependencies


### PR DESCRIPTION
## What

Reduce the CI test matrix from `[20, 22]` to a single **Node 20** job.

## Why

Stream Deck runs every plugin on the Node runtime pinned in `manifest.json` → `Nodejs.Version`. Elgato's CLI validator currently accepts **only `"20"`** — I confirmed `@elgato/cli@1.7.4` (latest) rejects `Nodejs.Version: "24"` with a schema `const` error, so 24 (though it appears in the docs) is not yet packable. Node 20 is the version that actually ships.

Testing Node 22 exercised a runtime the plugin never executes on and only added CI latency + a serialization point under `strict` branch protection.

## Also done

- Removed the now-obsolete **`Test (Node 22)`** required status check from `main` branch protection (required contexts now: Test (Node 20), Cross-Platform macOS/Windows, Code Quality & Coverage, Security Audit, CodeQL, E2E).

## When Elgato's packer accepts 24

Bump `Nodejs.Version` → `"24"`, the `node-version` refs, and `engines` in one change; the validator gate in the release workflow will confirm support.

632 tests pass, manifest validates, build clean.

https://claude.ai/code/session_01EUQgzWEdnQ4DFZxV4uAFMb