### PR TITLE
chore(release): plugin 2.7.11

### DIFF
--- a/com.felixgeelhaar.govee-light-management.sdPlugin/manifest.json
+++ b/com.felixgeelhaar.govee-light-management.sdPlugin/manifest.json
@@ -1,6 +1,6 @@
 {
   "Name": "Govee Light Management",
-  "Version": "2.7.10.0",
+  "Version": "2.7.11.0",
   "Author": "Felix Geelhaar",
   "URL": "https://github.com/felixgeelhaar/govee-light-management",
   "SupportURL": "https://github.com/felixgeelhaar/govee-light-management/issues",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "govee-light-management",
-  "version": "2.7.10",
+  "version": "2.7.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "govee-light-management",
-      "version": "2.7.10",
+      "version": "2.7.11",
       "license": "MIT",
       "dependencies": {
         "@elgato/streamdeck": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "govee-light-management",
-  "version": "2.7.10",
+  "version": "2.7.11",
   "description": "Enterprise-grade Stream Deck plugin for managing Govee lights with advanced group functionality",
   "main": "com.felixgeelhaar.govee-light-management.sdPlugin/bin/plugin.js",
   "scripts": {


### PR DESCRIPTION
Release **2.7.11** — patch.

## Included
- **fix(discovery):** resilient raw-fetch fallback so a single malformed device no longer hides the whole light list (#304, #305).

Version bumped in package.json, package-lock.json, and manifest.json (`2.7.11.0`). Runtime stays Node 20.

On merge, tag `v2.7.11` triggers the release workflow (build → validate → pack `.streamDeckPlugin` → GitHub release).

https://claude.ai/code/session_01EUQgzWEdnQ4DFZxV4uAFMb