### PR TITLE
chore(release): plugin 2.7.12

### DIFF
--- a/com.felixgeelhaar.govee-light-management.sdPlugin/manifest.json
+++ b/com.felixgeelhaar.govee-light-management.sdPlugin/manifest.json
@@ -1,6 +1,6 @@
 {
   "Name": "Govee Light Management",
-  "Version": "2.7.11.0",
+  "Version": "2.7.12.0",
   "Author": "Felix Geelhaar",
   "URL": "https://github.com/felixgeelhaar/govee-light-management",
   "SupportURL": "https://github.com/felixgeelhaar/govee-light-management/issues",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "govee-light-management",
-  "version": "2.7.11",
+  "version": "2.7.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "govee-light-management",
-      "version": "2.7.11",
+      "version": "2.7.12",
       "license": "MIT",
       "dependencies": {
         "@elgato/streamdeck": "^2.1.0",
-        "@felixgeelhaar/govee-api-client": "^3.3.9",
+        "@felixgeelhaar/govee-api-client": "^3.3.10",
         "zod": "4.4.3"
       },
       "devDependencies": {
@@ -550,9 +550,9 @@
       }
     },
     "node_modules/@felixgeelhaar/govee-api-client": {
-      "version": "3.3.9",
-      "resolved": "https://registry.npmjs.org/@felixgeelhaar/govee-api-client/-/govee-api-client-3.3.9.tgz",
-      "integrity": "sha512-S7BTUNfu5S9FCnEKeXtb8d6PFGujv/LsN7+hF4vM62e7IYf8NeSXnhu/ARVzWntBUhjKh0yHqWwU4A3+D89jmA==",
+      "version": "3.3.10",
+      "resolved": "https://registry.npmjs.org/@felixgeelhaar/govee-api-client/-/govee-api-client-3.3.10.tgz",
+      "integrity": "sha512-w4Rtc+7Xr6ek1Z/Y/+dX06ciDua1F1Clxhjkn8/U0tlkh9Wuhq0duiAdF47slzNxtAjPiEyh754g1XMatRsvqg==",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.16.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "govee-light-management",
-  "version": "2.7.11",
+  "version": "2.7.12",
   "description": "Enterprise-grade Stream Deck plugin for managing Govee lights with advanced group functionality",
   "main": "com.felixgeelhaar.govee-light-management.sdPlugin/bin/plugin.js",
   "scripts": {
@@ -62,7 +62,7 @@
   },
   "dependencies": {
     "@elgato/streamdeck": "^2.1.0",
-    "@felixgeelhaar/govee-api-client": "^3.3.9",
+    "@felixgeelhaar/govee-api-client": "^3.3.10",
     "zod": "4.4.3"
   },
   "overrides": {


### PR DESCRIPTION
Release **2.7.12** — patch.

## Included
- Bump `@felixgeelhaar/govee-api-client` **3.3.9 → 3.3.10**, delivering the root-cause discovery fix:
  - per-device + per-capability validation — a malformed capability drops only that capability, keeping the light controllable (client #41/#42)
  - structured "learning" logs for malformed Govee payloads (client #43)
- Complements the plugin's raw-fetch fallback from v2.7.11 (issue #304).

Version bumped in package.json, package-lock.json, manifest.json (`2.7.12.0`). 632 tests pass, build + typecheck clean.

On merge, tag `v2.7.12` triggers the release workflow (build → validate → pack → GitHub release).

https://claude.ai/code/session_01EUQgzWEdnQ4DFZxV4uAFMb