### PR TITLE
fix: attempt control regardless of the unreliable Govee online flag (#311)

### DIFF
--- a/src/backend/actions/MusicModeAction.ts
+++ b/src/backend/actions/MusicModeAction.ts
@@ -81,7 +81,9 @@ export class MusicModeAction extends SingletonAction<MusicModeSettings> {
           await this.services.applyMusicModeRaw(target.light, musicMode);
           anySucceeded = true;
         } else if (target.type === "group" && target.group) {
-          const members = target.group.getControllableLights();
+          // Attempt every member regardless of the unreliable online flag
+          // (#311); per-member failures are tolerated below.
+          const members = target.group.lights;
           totalCount = members.length;
           for (const light of members) {
             try {
@@ -195,13 +197,14 @@ export class MusicModeAction extends SingletonAction<MusicModeSettings> {
 
       await this.services.ensureServices(apiKey);
 
-      // For groups, query music modes from the first controllable member.
+      // For groups, query music modes from the first member (not filtered by
+      // the unreliable online flag, #311).
       const target = await this.services.resolveTarget({
         selectedDeviceId: deviceId,
       });
       let queryDeviceId = deviceId;
       if (target?.type === "group" && target.group) {
-        const first = target.group.getControllableLights()[0];
+        const first = target.group.lights[0];
         if (first) {
           queryDeviceId = `light:${first.deviceId}|${first.model}`;
         }

--- a/src/backend/actions/RecallAction.ts
+++ b/src/backend/actions/RecallAction.ts
@@ -117,7 +117,8 @@ export class RecallAction extends SingletonAction<RecallSettings> {
         await applyRecallToLight(this.services, target.light, parsed);
         anySucceeded = true;
       } else if (target.type === "group" && target.group) {
-        const members = target.group.getControllableLights();
+        // #311: iterate all members; the online flag is unreliable
+        const members = target.group.lights;
         totalCount = members.length;
         for (const light of members) {
           try {
@@ -252,7 +253,8 @@ export class RecallAction extends SingletonAction<RecallSettings> {
       if (target?.type === "light" && target.light) {
         queryLight = target.light;
       } else if (target?.type === "group" && target.group) {
-        queryLight = target.group.getControllableLights()[0];
+        // #311: pick from all members; the online flag is unreliable
+        queryLight = target.group.lights[0];
       }
 
       if (!queryLight) {

--- a/src/backend/actions/SceneAction.ts
+++ b/src/backend/actions/SceneAction.ts
@@ -90,7 +90,8 @@ export class SceneAction extends SingletonAction<SceneSettings> {
             await this.services.applyDiyScene(target.light, scene);
             anySucceeded = true;
           } else if (target.type === "group" && target.group) {
-            const members = target.group.getControllableLights();
+            // #311: iterate all members; the online flag is unreliable
+            const members = target.group.lights;
             totalCount = members.length;
             for (const light of members) {
               try {
@@ -115,7 +116,8 @@ export class SceneAction extends SingletonAction<SceneSettings> {
             await this.services.applyDynamicScene(target.light, scene);
             anySucceeded = true;
           } else if (target.type === "group" && target.group) {
-            const members = target.group.getControllableLights();
+            // #311: iterate all members; the online flag is unreliable
+            const members = target.group.lights;
             totalCount = members.length;
             for (const light of members) {
               try {
@@ -237,7 +239,8 @@ export class SceneAction extends SingletonAction<SceneSettings> {
       if (target?.type === "light" && target.light) {
         queryLight = target.light;
       } else if (target?.type === "group" && target.group) {
-        const members = target.group.getControllableLights();
+        // #311: pick from all members; the online flag is unreliable
+        const members = target.group.lights;
         queryLight = members[0];
       }
 

--- a/src/backend/actions/SegmentColorAction.ts
+++ b/src/backend/actions/SegmentColorAction.ts
@@ -88,7 +88,8 @@ export class SegmentColorAction extends BaseDialAction<SegmentColorSettings> {
       if (target.type === "light" && target.light) {
         await this.services.setSegmentColors(target.light, segments);
       } else if (target.type === "group" && target.group) {
-        const members = target.group.getControllableLights();
+        // #311: iterate all members; the online flag is unreliable
+        const members = target.group.lights;
         let anySucceeded = false;
         let failedCount = 0;
         for (const light of members) {
@@ -328,9 +329,10 @@ export class SegmentColorAction extends BaseDialAction<SegmentColorSettings> {
       return;
     }
     if (target.type === "group" && target.group) {
-      const capable = target.group
-        .getControllableLights()
-        .filter((l) => l.supportsSegmentedColor());
+      // #311: iterate all members; the online flag is unreliable
+      const capable = target.group.lights.filter((l) =>
+        l.supportsSegmentedColor(),
+      );
       if (capable.length === 0) {
         throw new Error("Group has no segmented-color-capable lights");
       }

--- a/src/backend/actions/SegmentColorDialAction.ts
+++ b/src/backend/actions/SegmentColorDialAction.ts
@@ -154,9 +154,10 @@ export class SegmentColorDialAction extends BaseDialAction<SegmentColorDialSetti
     }
 
     if (target.type === "group" && target.group) {
-      const capable = target.group
-        .getControllableLights()
-        .filter((l) => l.supportsSegmentedColor());
+      // #311: iterate all members; the online flag is unreliable
+      const capable = target.group.lights.filter((l) =>
+        l.supportsSegmentedColor(),
+      );
       if (capable.length === 0) {
         streamDeck.logger.warn(
           `Segment color: group ${target.group.name} has no segmented-color-capable members`,

--- a/src/backend/actions/SequenceAction.ts
+++ b/src/backend/actions/SequenceAction.ts
@@ -143,7 +143,8 @@ export class SequenceAction extends SingletonAction<SequenceSettings> {
     });
     if (target?.type === "light" && target.light) return target.light;
     if (target?.type === "group" && target.group) {
-      return target.group.getControllableLights()[0];
+      // #311: pick from all members; the online flag is unreliable
+      return target.group.lights[0];
     }
     return undefined;
   }
@@ -295,7 +296,8 @@ export class SequenceAction extends SingletonAction<SequenceSettings> {
       });
       let queryDeviceId = targetId;
       if (target?.type === "group" && target.group) {
-        const first = target.group.getControllableLights()[0];
+        // #311: pick from all members; the online flag is unreliable
+        const first = target.group.lights[0];
         if (first) queryDeviceId = `light:${first.deviceId}|${first.model}`;
       }
       const modes = await this.services.getMusicModes(queryDeviceId);
@@ -358,7 +360,8 @@ export class SequenceAction extends SingletonAction<SequenceSettings> {
       });
       let queryDeviceId = targetId;
       if (target?.type === "group" && target.group) {
-        const first = target.group.getControllableLights()[0];
+        // #311: pick from all members; the online flag is unreliable
+        const first = target.group.lights[0];
         if (first) queryDeviceId = `light:${first.deviceId}|${first.model}`;
       }
       const features = await this.services.getToggleFeatures(queryDeviceId);

--- a/src/backend/actions/SnapshotAction.ts
+++ b/src/backend/actions/SnapshotAction.ts
@@ -84,9 +84,10 @@ export class SnapshotAction extends SingletonAction<SnapshotSettings> {
           await this.services.applySnapshot(target.light, snapshot);
           anySucceeded = true;
         } else if (target.type === "group" && target.group) {
-          // Apply snapshot to each controllable group member sequentially.
+          // Apply snapshot to each group member sequentially.
           // Groups don't have a single-call path for snapshots.
-          const members = target.group.getControllableLights();
+          // #311: iterate all members; the online flag is unreliable
+          const members = target.group.lights;
           totalCount = members.length;
           for (const member of members) {
             try {
@@ -204,7 +205,8 @@ export class SnapshotAction extends SingletonAction<SnapshotSettings> {
       if (target?.type === "light" && target.light) {
         queryLight = target.light;
       } else if (target?.type === "group" && target.group) {
-        const members = target.group.getControllableLights();
+        // #311: pick from all members; the online flag is unreliable
+        const members = target.group.lights;
         queryLight = members[0];
       }
 

--- a/src/backend/actions/ToggleAction.ts
+++ b/src/backend/actions/ToggleAction.ts
@@ -127,10 +127,9 @@ export class ToggleAction extends SingletonAction<ToggleSettings> {
       if (operation === "toggle") {
         // For toggle mode, read live state from the first available light.
         let liveState: boolean | undefined;
+        // #311: pick from all members; the online flag is unreliable
         const queryLight =
-          target.type === "light"
-            ? target.light
-            : target.group?.getControllableLights()[0];
+          target.type === "light" ? target.light : target.group?.lights[0];
         if (queryLight) {
           try {
             liveState = await this.services.getToggleFeatureState(
@@ -179,7 +178,8 @@ export class ToggleAction extends SingletonAction<ToggleSettings> {
             singleLightUnapplied = true;
           }
         } else if (target.type === "group" && target.group) {
-          const members = target.group.getControllableLights();
+          // #311: iterate all members; the online flag is unreliable
+          const members = target.group.lights;
           totalCount = members.length;
           for (const light of members) {
             try {
@@ -314,7 +314,8 @@ export class ToggleAction extends SingletonAction<ToggleSettings> {
       });
       let queryDeviceId = deviceId;
       if (target?.type === "group" && target.group) {
-        const first = target.group.getControllableLights()[0];
+        // #311: pick from all members; the online flag is unreliable
+        const first = target.group.lights[0];
         if (first) {
           queryDeviceId = `light:${first.deviceId}|${first.model}`;
         }

--- a/src/backend/actions/shared/ActionServices.ts
+++ b/src/backend/actions/shared/ActionServices.ts
@@ -1248,7 +1248,10 @@ export class ActionServices {
           // brightness / colour value via the shared snapshot cache.
           // Without this, toggling a group from one action leaves the
           // dial state stale until the live-sync timer next refreshes.
-          for (const light of target.group.getControllableLights()) {
+          // #311: remember all members — controlGroup commanded all of them,
+          // so a member wrongly flagged offline must still have its new state
+          // cached (the online flag is unreliable).
+          for (const light of target.group.lights) {
             this.rememberLightState(light);
           }
         }

--- a/src/backend/actions/shared/ActionServices.ts
+++ b/src/backend/actions/shared/ActionServices.ts
@@ -1179,7 +1179,8 @@ export class ActionServices {
       targetIds.push(`light:${target.light.deviceId}|${target.light.model}`);
     } else if (target.type === "group" && target.group) {
       targetIds.push(`group:${target.group.id}`);
-      for (const light of target.group.getControllableLights()) {
+      // #311: iterate all members; the online flag is unreliable
+      for (const light of target.group.lights) {
         targetIds.push(`light:${light.deviceId}|${light.model}`);
       }
     }
@@ -1806,7 +1807,8 @@ export class ActionServices {
     if (target.type === "light" && target.light) {
       await this.ensurePreparedForSolidColor(contextId, target.light);
     } else if (target.type === "group" && target.group) {
-      for (const light of target.group.getControllableLights()) {
+      // #311: iterate all members; the online flag is unreliable
+      for (const light of target.group.lights) {
         await this.ensurePreparedForSolidColor(contextId, light);
       }
     }

--- a/src/backend/domain/services/LightControlService.ts
+++ b/src/backend/domain/services/LightControlService.ts
@@ -16,12 +16,12 @@ export class LightControlService {
     action: "on" | "off" | "brightness" | "color" | "colorTemperature",
     value?: Brightness | ColorRgb | ColorTemperature,
   ): Promise<void> {
-    if (!light.canBeControlled()) {
-      throw new Error(
-        `Light ${light.name} is offline and cannot be controlled`,
-      );
-    }
-
+    // Attempt control regardless of the device's reported online status. The
+    // Govee cloud API's `online` flag is unreliable and frequently reports
+    // reachable devices (e.g. H619A string lights) as offline (#311), so
+    // pre-blocking here refuses a working device. Instead we send the command
+    // and let the transport/repository surface a real error if it genuinely
+    // fails. `isOnline` is retained only as a display hint.
     switch (action) {
       case "on":
         await this.lightRepository.setPower(light, true);
@@ -72,12 +72,15 @@ export class LightControlService {
     action: "on" | "off" | "brightness" | "color" | "colorTemperature",
     value?: Brightness | ColorRgb | ColorTemperature,
   ): Promise<void> {
-    if (!group.canBeControlled()) {
-      throw new Error(`Group ${group.name} has no controllable lights`);
+    const lights = group.lights;
+    if (lights.length === 0) {
+      throw new Error(`Group ${group.name} has no lights`);
     }
 
-    const controllableLights = group.getControllableLights();
-    const promises = controllableLights.map((light) =>
+    // Attempt every member regardless of its reported online flag (see
+    // controlLight): offline-flagged members are no longer pre-filtered out,
+    // because that flag is unreliable (#311).
+    const promises = lights.map((light) =>
       this.controlLight(light, action, value),
     );
 
@@ -96,12 +99,9 @@ export class LightControlService {
       colorTemperature?: ColorTemperature;
     },
   ): Promise<void> {
-    if (!light.canBeControlled()) {
-      throw new Error(
-        `Light ${light.name} is offline and cannot be controlled`,
-      );
-    }
-
+    // Attempt regardless of the reported online status (see controlLight): the
+    // Govee `online` flag is unreliable and must not pre-block a working
+    // device (#311).
     const { brightness, color, colorTemperature } = settings;
 
     if (color && colorTemperature) {
@@ -150,12 +150,14 @@ export class LightControlService {
       colorTemperature?: ColorTemperature;
     },
   ): Promise<void> {
-    if (!group.canBeControlled()) {
-      throw new Error(`Group ${group.name} has no controllable lights`);
+    const lights = group.lights;
+    if (lights.length === 0) {
+      throw new Error(`Group ${group.name} has no lights`);
     }
 
-    const controllableLights = group.getControllableLights();
-    const promises = controllableLights.map((light) =>
+    // Attempt every member regardless of the reported online flag (see
+    // controlLight); the flag is unreliable (#311).
+    const promises = lights.map((light) =>
       this.turnOnLightWithSettings(light, settings),
     );
 

--- a/src/backend/domain/services/SceneService.ts
+++ b/src/backend/domain/services/SceneService.ts
@@ -69,6 +69,7 @@ export class SceneService {
    * Check if a scene can be applied to a light
    */
   canApplyScene(light: Light): boolean {
-    return light.supportsScenes() && light.canBeControlled();
+    // #311: depend only on the real capability; the online flag is unreliable
+    return light.supportsScenes();
   }
 }

--- a/src/backend/domain/services/SceneService.ts
+++ b/src/backend/domain/services/SceneService.ts
@@ -14,10 +14,8 @@ export class SceneService {
    * Apply a scene to a single light
    */
   async applySceneToLight(light: Light, scene: Scene): Promise<void> {
-    if (!light.canBeControlled()) {
-      throw new Error(`${light.name} is offline and cannot be controlled`);
-    }
-
+    // Attempt regardless of the reported online status — the Govee `online`
+    // flag is unreliable (#311). The capability check below is a real guard.
     if (!light.supportsScenes()) {
       throw new Error(`${light.name} does not support scene control`);
     }
@@ -29,9 +27,9 @@ export class SceneService {
    * Apply a scene to all lights in a group that support scenes
    */
   async applySceneToGroup(group: LightGroup, scene: Scene): Promise<void> {
-    const sceneLights = group.lights.filter(
-      (light) => light.supportsScenes() && light.canBeControlled(),
-    );
+    // Filter only on the real capability (scene support), not the unreliable
+    // online flag (#311) — attempt every scene-capable member.
+    const sceneLights = group.lights.filter((light) => light.supportsScenes());
 
     if (sceneLights.length === 0) {
       throw new Error(`${group.name} has no lights with scene support`);

--- a/src/backend/services/SequenceService.ts
+++ b/src/backend/services/SequenceService.ts
@@ -92,10 +92,11 @@ class SequenceServiceImpl {
 
     if (step.command === "scene" && step.scenePayload) {
       const payload = step.scenePayload;
+      // #311: iterate all members; the online flag is unreliable
       const lights =
         target.type === "light" && target.light
           ? [target.light]
-          : (target.group?.getControllableLights() ?? []);
+          : (target.group?.lights ?? []);
       for (const light of lights) {
         try {
           if (payload.kind === "diy") {
@@ -130,10 +131,11 @@ class SequenceServiceImpl {
         payload.paramId,
         payload.name,
       );
+      // #311: iterate all members; the online flag is unreliable
       const lights =
         target.type === "light" && target.light
           ? [target.light]
-          : (target.group?.getControllableLights() ?? []);
+          : (target.group?.lights ?? []);
       for (const light of lights) {
         try {
           await this.actionServices.applySnapshot(light, snapshot);
@@ -153,10 +155,11 @@ class SequenceServiceImpl {
         payload.modeId,
         payload.sensitivity,
       );
+      // #311: iterate all members; the online flag is unreliable
       const lights =
         target.type === "light" && target.light
           ? [target.light]
-          : (target.group?.getControllableLights() ?? []);
+          : (target.group?.lights ?? []);
       for (const light of lights) {
         try {
           await this.actionServices.applyMusicModeRaw(light, musicMode);
@@ -172,10 +175,11 @@ class SequenceServiceImpl {
 
     if (step.command === "feature-toggle" && step.togglePayload) {
       const payload = step.togglePayload;
+      // #311: iterate all members; the online flag is unreliable
       const lights =
         target.type === "light" && target.light
           ? [target.light]
-          : (target.group?.getControllableLights() ?? []);
+          : (target.group?.lights ?? []);
       for (const light of lights) {
         try {
           await this.actionServices.toggleFeatureRaw(
@@ -198,10 +202,11 @@ class SequenceServiceImpl {
       const segments: SegmentColor[] = payload.segments.map((seg) =>
         SegmentColor.create(seg.index, ColorRgb.fromHex(seg.hex)),
       );
+      // #311: iterate all members; the online flag is unreliable
       const lights =
         target.type === "light" && target.light
           ? [target.light]
-          : (target.group?.getControllableLights() ?? []);
+          : (target.group?.lights ?? []);
       for (const light of lights) {
         try {
           await this.actionServices.setSegmentColors(light, segments);
@@ -227,10 +232,11 @@ class SequenceServiceImpl {
       // Effects run on single lights only. For groups, kick off playback on
       // each controllable light. Fire-and-forget so sequence progression isn't
       // blocked by a looping effect — the user can cancel it manually later.
+      // #311: iterate all members; the online flag is unreliable
       const lights =
         target.type === "light" && target.light
           ? [target.light]
-          : (target.group?.getControllableLights() ?? []);
+          : (target.group?.lights ?? []);
       for (const light of lights) {
         const targetId = `light:${light.deviceId}|${light.model}`;
         void effectService.playEffect(targetId, preset).catch((error) => {

--- a/test/backend/actions/shared/ActionServices.test.ts
+++ b/test/backend/actions/shared/ActionServices.test.ts
@@ -304,7 +304,9 @@ describe("ActionServices.ensurePreparedForTarget", () => {
     }
   });
 
-  it("prepares each controllable light in a group target", async () => {
+  it("prepares every group member, including one flagged offline (#311)", async () => {
+    // The Govee `online` flag is unreliable, so preparation must iterate all
+    // members via group.lights rather than filtering on the flag.
     const repo = mockRepo();
     const restore = installMockRepo(repo);
     try {
@@ -318,11 +320,11 @@ describe("ActionServices.ensurePreparedForTarget", () => {
         deviceId: "grp-b",
         gradient: true,
       });
+      // Flag lightB offline: the old getControllableLights() path would drop
+      // it; the lenient path still prepares it.
+      lightB.updateState({ isOnline: false });
 
-      // Minimal LightGroup stub — only getControllableLights is called.
-      const group = {
-        getControllableLights: () => [lightA, lightB],
-      } as unknown as import("../../../../src/backend/domain/entities/LightGroup").LightGroup;
+      const group = LightGroup.create("grp-1", "Living Room", [lightA, lightB]);
 
       await services.ensurePreparedForTarget("ctx-1", {
         type: "group",
@@ -388,6 +390,26 @@ describe("ActionServices.cancelActiveEffectForTarget", () => {
     const services = new ActionServices();
     const l1 = makeLight({ deviceId: "a", model: "H6001" });
     const l2 = makeLight({ deviceId: "b", model: "H6002" });
+    const group = LightGroup.create("grp-1", "Living Room", [l1, l2]);
+
+    await services.cancelActiveEffectForTarget({ type: "group", group });
+
+    expect(canceller.mock.calls.map((c) => c[0])).toEqual([
+      "group:grp-1",
+      "light:a|H6001",
+      "light:b|H6002",
+    ]);
+  });
+
+  it("cancels a group member even when it is flagged offline (#311)", async () => {
+    // The Govee `online` flag is unreliable, so effect cancellation must reach
+    // every member — a member flagged offline is still cancelled.
+    const canceller = vi.fn().mockResolvedValue(true);
+    registerEffectCanceller(canceller);
+    const services = new ActionServices();
+    const l1 = makeLight({ deviceId: "a", model: "H6001" });
+    const l2 = makeLight({ deviceId: "b", model: "H6002" });
+    l2.updateState({ isOnline: false });
     const group = LightGroup.create("grp-1", "Living Room", [l1, l2]);
 
     await services.cancelActiveEffectForTarget({ type: "group", group });

--- a/test/domain/services/LightControlService.test.ts
+++ b/test/domain/services/LightControlService.test.ts
@@ -90,12 +90,24 @@ describe('LightControlService', () => {
       expect(mockLightRepository.setColorTemperature).toHaveBeenCalledWith(mockLight, colorTemp);
     });
 
-    it('should throw error for offline lights', async () => {
+    it('should attempt control on lights flagged offline (unreliable online flag, #311)', async () => {
+      // The Govee cloud `online` flag is unreliable and often reports reachable
+      // devices as offline. Control must be attempted, not pre-blocked.
       const offlineLight = createMockLight('offline', 'Offline Light', false, false);
+      mockLightRepository.setPower.mockResolvedValue(undefined);
+
+      await service.controlLight(offlineLight, 'on');
+
+      expect(mockLightRepository.setPower).toHaveBeenCalledWith(offlineLight, true);
+    });
+
+    it('should surface the real transport error when a flagged-offline device genuinely fails', async () => {
+      const offlineLight = createMockLight('offline', 'Offline Light', false, false);
+      mockLightRepository.setPower.mockRejectedValue(new Error('device unreachable'));
 
       await expect(
         service.controlLight(offlineLight, 'on')
-      ).rejects.toThrow('Light Offline Light is offline and cannot be controlled');
+      ).rejects.toThrow('device unreachable');
     });
 
     it('should turn on light with settings', async () => {
@@ -121,16 +133,16 @@ describe('LightControlService', () => {
       expect(mockLightRepository.setPower).toHaveBeenCalledTimes(2);
     });
 
-    it('should skip offline lights in group', async () => {
-      // Make one light offline
+    it('should attempt all members regardless of the offline flag (#311)', async () => {
+      // A member flagged offline is no longer pre-filtered — the flag is
+      // unreliable, so every member gets the command.
       const lights = mockGroup.lights;
       lights[1].updateState({ isOnline: false });
       mockLightRepository.setPower.mockResolvedValue(undefined);
 
       await service.controlGroup(mockGroup, 'on');
 
-      // Should only control the online light
-      expect(mockLightRepository.setPower).toHaveBeenCalledTimes(1);
+      expect(mockLightRepository.setPower).toHaveBeenCalledTimes(2);
     });
 
     it('should turn on group with settings', async () => {
@@ -151,7 +163,7 @@ describe('LightControlService', () => {
 
       await expect(
         service.controlGroup(emptyGroup, 'on')
-      ).rejects.toThrow('Group Empty Group has no controllable lights');
+      ).rejects.toThrow('Group Empty Group has no lights');
     });
   });
 

--- a/test/domain/services/SceneService.test.ts
+++ b/test/domain/services/SceneService.test.ts
@@ -282,9 +282,11 @@ describe("SceneService", () => {
       expect(sceneService.canApplyScene(testLightWithoutScenes)).toBe(false);
     });
 
-    it("should return false if light is offline", () => {
+    it("should return true even when the light is flagged offline (#311)", () => {
+      // The Govee `online` flag is unreliable, so scene applicability
+      // depends only on the real capability, not the offline flag.
       testLight.updateState({ isOnline: false });
-      expect(sceneService.canApplyScene(testLight)).toBe(false);
+      expect(sceneService.canApplyScene(testLight)).toBe(true);
     });
   });
 });

--- a/test/domain/services/SceneService.test.ts
+++ b/test/domain/services/SceneService.test.ts
@@ -101,13 +101,15 @@ describe("SceneService", () => {
       expect(mockRepository.applyScene).toHaveBeenCalledWith(testLight, scene);
     });
 
-    it("should throw error if light is offline", async () => {
+    it("should attempt to apply a scene even when flagged offline (#311)", async () => {
+      // The Govee `online` flag is unreliable; scene control must be attempted,
+      // not pre-blocked.
       const scene = Scene.sunset();
       testLight.updateState({ isOnline: false });
 
-      await expect(
-        sceneService.applySceneToLight(testLight, scene)
-      ).rejects.toThrow("Test Light is offline and cannot be controlled");
+      await sceneService.applySceneToLight(testLight, scene);
+
+      expect(mockRepository.applyScene).toHaveBeenCalledWith(testLight, scene);
     });
 
     it("should throw error if light does not support scenes", async () => {
@@ -187,16 +189,15 @@ describe("SceneService", () => {
       ).rejects.toThrow("No Scenes Group has no lights with scene support");
     });
 
-    it("should throw error when all lights with scene support are offline", async () => {
+    it("should still attempt scene-capable lights that are flagged offline (#311)", async () => {
+      // The online flag is unreliable, so a scene-capable member flagged
+      // offline is attempted rather than filtered out.
       testLight.updateState({ isOnline: false });
       const scene = Scene.sunset();
 
-      await expect(
-        sceneService.applySceneToGroup(testGroup, scene)
-      ).rejects.toThrow("Test Group has no lights with scene support");
+      await sceneService.applySceneToGroup(testGroup, scene);
 
-      // No repository calls should be made
-      expect(mockRepository.applyScene).not.toHaveBeenCalled();
+      expect(mockRepository.applyScene).toHaveBeenCalledWith(testLight, scene);
     });
 
     it("should apply scene to multiple lights in parallel", async () => {


### PR DESCRIPTION
## Summary

Fixes **#311** — devices are discovered fine but cannot be controlled; the plugin throws *"X is offline and cannot be controlled"* (green warning on the Stream Deck key) without ever sending the command. Reported for **H619A Outdoor String Lights** on plugin 2.7.12.

## Root cause

The control gate is `Light.canBeControlled()`, which returns `_state.isOnline`. That value is set **directly from the Govee cloud API's `online` field** in `GoveeLightRepository.getLightState()`:

```ts
isOnline: deviceState.isOnline(),   // GoveeLightRepository.ts:381
```

The Govee cloud `online` flag is unreliable and frequently reports **reachable** devices as offline (WiFi string lights like the H619A are a known case). So the device lists, but any control attempt is pre-blocked by the stale flag — the command is never sent.

This is the same class of cloud-API flakiness that caused **#304** (discovery), which was fixed by making discovery lenient. The **control path** never got the same treatment — this PR applies it.

## Fix

Make the control-execution path lenient: **attempt the command and let the transport surface a real error only if it genuinely fails.** `isOnline` / `getControllableLights()` are retained unchanged for display, power-icon aggregation, and offline→online recovery — only *control* stops pre-blocking on the flag.

- `LightControlService.controlLight` / `turnOnLightWithSettings`: drop the `isOnline` guard.
- `LightControlService.controlGroup` / `turnOnGroupWithSettings`: control **all** group members (not just `getControllableLights()`); throw only for a genuinely empty group.
- `SceneService.applySceneToLight` / `applySceneToGroup`: filter on the real `supportsScenes()` capability only, not the online flag.
- `MusicModeAction`: select group members and the mode-query light from all members (per-member failures are already tolerated).

## Behavior change

A device the API reports as offline is now **sent the command**; if it is genuinely unreachable, the real transport error surfaces (as it does for any other failure) instead of a blanket pre-block. The Stream Deck warning that appeared because control threw will now clear on success.

## Tests

- Updated the tests that asserted the old pre-block (single light, group, scene) to the lenient contract.
- New cases: a flagged-offline device **is** attempted; a genuine transport failure on a flagged-offline device **still** surfaces the error.
- Full suite green (**633 passed**), typecheck + lint + build clean.

https://claude.ai/code/session_01QKTcmXFTKoTQr7mB3HCuHZ
