### PR TITLE
test: convert CircuitBreaker suite to fake timers (remove CI-load flake)

### DIFF
--- a/test/integration/resilience/CircuitBreaker.test.ts
+++ b/test/integration/resilience/CircuitBreaker.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { CircuitBreaker, CircuitState, CircuitBreakerOpenError, CircuitBreakerFactory } from '../../../src/backend/infrastructure/resilience/CircuitBreaker';
 
 // Mock streamDeck logger
@@ -17,12 +17,17 @@ describe('CircuitBreaker Integration Tests', () => {
   let circuitBreaker: CircuitBreaker;
 
   beforeEach(() => {
+    vi.useFakeTimers();
     circuitBreaker = new CircuitBreaker('test-circuit', {
       failureThreshold: 3,
       recoveryTimeout: 1000, // 1 second for testing
       successThreshold: 2,
       timeout: 500, // 0.5 seconds
     });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   describe('Normal Operation (CLOSED state)', () => {
@@ -98,7 +103,7 @@ describe('CircuitBreaker Integration Tests', () => {
       expect(circuitBreaker.getStats().state).toBe(CircuitState.OPEN);
 
       // Wait for recovery timeout
-      await new Promise(resolve => setTimeout(resolve, 1100));
+      await vi.advanceTimersByTimeAsync(1100);
 
       // Next operation should transition to HALF_OPEN
       const testOperation = vi.fn().mockResolvedValue('test recovery');
@@ -113,7 +118,7 @@ describe('CircuitBreaker Integration Tests', () => {
       await forceCircuitOpen(circuitBreaker);
 
       // Wait for recovery timeout
-      await new Promise(resolve => setTimeout(resolve, 1100));
+      await vi.advanceTimersByTimeAsync(1100);
 
       // Execute successful operations to meet success threshold
       const successOperation = vi.fn().mockResolvedValue('success');
@@ -130,7 +135,7 @@ describe('CircuitBreaker Integration Tests', () => {
       await forceCircuitOpen(circuitBreaker);
 
       // Wait for recovery timeout
-      await new Promise(resolve => setTimeout(resolve, 1100));
+      await vi.advanceTimersByTimeAsync(1100);
 
       // Try a failing operation
       const failingOperation = vi.fn().mockRejectedValue(new Error('Still failing'));
@@ -146,7 +151,13 @@ describe('CircuitBreaker Integration Tests', () => {
         () => new Promise(resolve => setTimeout(() => resolve('too slow'), 1000))
       );
 
-      await expect(circuitBreaker.execute(longRunningOperation)).rejects.toThrow('Operation timeout');
+      // Start the call without awaiting so its promise stays pending, then
+      // advance fake time to the breaker's 500ms timeout (before the
+      // operation's own 1000ms resolve) so the timeout wins the race.
+      const promise = circuitBreaker.execute(longRunningOperation);
+      const assertion = expect(promise).rejects.toThrow('Operation timeout');
+      await vi.advanceTimersByTimeAsync(500);
+      await assertion;
       expect(circuitBreaker.getStats().failureCount).toBe(1);
     });
   });
@@ -245,7 +256,7 @@ describe('CircuitBreaker Integration Tests', () => {
       await forceCircuitOpen(circuitBreaker);
 
       // Wait for recovery
-      await new Promise(resolve => setTimeout(resolve, 1100));
+      await vi.advanceTimersByTimeAsync(1100);
 
       // Immediate success should work
       const successOperation = vi.fn().mockResolvedValue('immediate success');


### PR DESCRIPTION
## Summary

Converts `test/integration/resilience/CircuitBreaker.test.ts` from real `setTimeout` waits to vitest fake timers. This is purely a timing-mechanism change — no behavior, assertions, config values, or test names were altered.

## Why

The suite previously slept against wall-clock time to cross the circuit breaker's `recoveryTimeout: 1000ms` boundary, using `await new Promise(resolve => setTimeout(resolve, 1100))` — a **100ms margin** repeated at 4 recovery sites, plus a timeout test racing a 1000ms operation against the breaker's 500ms `timeout`. On loaded CI runners a 100ms scheduling margin is not a safe guarantee: if the runner stalls the event loop past the margin, the wall clock can pass `nextAttemptTime` unpredictably relative to the sleep, and the timeout race can invert. This was the **only real-timer flake vector** exercised across the 4 required checks (vitest, tsc, lint, build).

`CircuitBreaker` recovery is wall-clock based (`Date.now() >= this.nextAttemptTime.getTime()`) and its per-operation timeout uses `setTimeout` via `Promise.race`. `vi.useFakeTimers()` mocks **both** `Date`/`Date.now()` and `setTimeout`, so advancing fake time deterministically drives both mechanisms — removing all real waits.

## Changes

- Added `beforeEach(() => vi.useFakeTimers())` / `afterEach(() => vi.useRealTimers())` (imported `afterEach`).
- Replaced every `await new Promise(resolve => setTimeout(resolve, 1100))` recovery wait with `await vi.advanceTimersByTimeAsync(1100)`.
- Reworked the operation-timeout test to start the call without awaiting, then `advanceTimersByTimeAsync(500)` so the breaker's 500ms timeout wins the race before the operation's own 1000ms resolve; the pending rejection is asserted promptly via `expect(...).rejects` to avoid unhandled-rejection warnings.

## Verification

- Target file run 20/20 times: all `16 passed`, ~0.67s wall each (all Node startup — the test work itself is 6ms vs the prior ~5.5s of real sleeps).
- Full suite: 632 passed (45 files). `tsc --noEmit`: clean. `npm run lint`: clean. `npm run build`: succeeded.

https://claude.ai/code/session_01QKTcmXFTKoTQr7mB3HCuHZ
