### PR TITLE
chore(release): plugin 2.7.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project are documented below. This project adheres t
 
 ---
 
+## [2.7.13] - 2026-07-06
+
+### Fixed
+
+- **Devices could be discovered but not controlled — "X is offline and cannot be controlled"** ([#311](https://github.com/felixgeelhaar/govee-light-management/issues/311)). Reported for H619A Outdoor String Lights: the plugin listed the devices but every control attempt (On/Off, brightness, …) failed with a green warning and no command sent. The control gate (`Light.canBeControlled()`) was derived from the Govee cloud API's `online` flag, which is unreliable and frequently reports reachable devices as offline (the same class of cloud-API flakiness behind the #304 discovery bug). The control path now **attempts the command regardless of the online flag** and surfaces a real transport error only if it genuinely fails; `isOnline` is retained only as a display hint. The fix is applied consistently across every command type — power, brightness, color, color temperature, scenes, music mode, snapshots, recall, feature toggles, segment color, and sequence steps — and to group control (all members are commanded, not just those flagged online). Post-command state is also cached for every commanded member so other actions reflect it immediately.
+
+### Internal
+
+- Converted the CircuitBreaker resilience test suite to fake timers, removing a low-probability CI-load flake vector from the required test checks (no runtime behavior change).
+
 ## [2.7.5] - 2026-05-16
 
 ### Fixed

--- a/com.felixgeelhaar.govee-light-management.sdPlugin/manifest.json
+++ b/com.felixgeelhaar.govee-light-management.sdPlugin/manifest.json
@@ -1,6 +1,6 @@
 {
   "Name": "Govee Light Management",
-  "Version": "2.7.12.0",
+  "Version": "2.7.13.0",
   "Author": "Felix Geelhaar",
   "URL": "https://github.com/felixgeelhaar/govee-light-management",
   "SupportURL": "https://github.com/felixgeelhaar/govee-light-management/issues",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "govee-light-management",
-  "version": "2.7.12",
+  "version": "2.7.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "govee-light-management",
-      "version": "2.7.12",
+      "version": "2.7.13",
       "license": "MIT",
       "dependencies": {
         "@elgato/streamdeck": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "govee-light-management",
-  "version": "2.7.12",
+  "version": "2.7.13",
   "description": "Enterprise-grade Stream Deck plugin for managing Govee lights with advanced group functionality",
   "main": "com.felixgeelhaar.govee-light-management.sdPlugin/bin/plugin.js",
   "scripts": {


### PR DESCRIPTION
Version bump to **2.7.13** for release. Ships:

- **#311 fix** — control is attempted regardless of the unreliable Govee `online` flag, across every command type (power/brightness/color/temp/scenes/music/snapshot/recall/toggle/segment/sequence) + group control. Fixes 'X is offline and cannot be controlled' on reachable devices (H619A).
- CircuitBreaker test suite converted to fake timers (removes a CI-load flake vector).

Bumps package.json, package-lock.json, manifest.json (2.7.13.0) + CHANGELOG. `streamdeck validate` + build pass locally; full suite green (634).

Merge → tag `v2.7.13` triggers the release workflow (validate + pack + GitHub release).

https://claude.ai/code/session_01QKTcmXFTKoTQr7mB3HCuHZ