### PR TITLE
fix(ci): nox writes results.sarif, not findings.sarif

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,10 +179,10 @@ jobs:
         run: nox scan . -format json,sarif -output nox-results || true
 
       - name: Upload nox SARIF to code scanning
-        if: always() && hashFiles('nox-results/findings.sarif') != ''
+        if: always() && hashFiles('nox-results/results.sarif') != ''
         uses: github/codeql-action/upload-sarif@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4
         with:
-          sarif_file: nox-results/findings.sarif
+          sarif_file: nox-results/results.sarif
           category: nox
 
       - name: Gate on critical/high nox findings


### PR DESCRIPTION
The SARIF upload step guarded on `nox-results/findings.sarif`, but nox 1.7.1 writes `nox-results/results.sarif` — so the code-scanning upload was silently skipping. The enforcing gate reads `findings.json` and was unaffected (observability fix). Verified against nox 1.7.1; same fix applied to the central `felixgeelhaar/.github` reusables.

https://claude.ai/code/session_01XsciE5KjxtMrHimxWxBVFS