### PR TITLE
fix(diagnostics): explain why control fails instead of a bare warning (#311)

### DIFF
--- a/src/backend/actions/OnOffAction.ts
+++ b/src/backend/actions/OnOffAction.ts
@@ -147,14 +147,10 @@ export class OnOffAction extends SingletonAction<OnOffSettings> {
 
     const apiKey = await this.services.getApiKey(settings);
     if (!apiKey || !settings.selectedDeviceId) {
-      await ev.action.showAlert();
-      return;
-    }
-
-    await this.services.ensureServices(apiKey);
-    const target = await this.services.resolveTarget(settings);
-
-    if (!target) {
+      streamDeck.logger.warn("Key press ignored: not configured", {
+        hasApiKey: Boolean(apiKey),
+        hasSelectedDevice: Boolean(settings.selectedDeviceId),
+      });
       await ev.action.showAlert();
       return;
     }
@@ -163,7 +159,22 @@ export class OnOffAction extends SingletonAction<OnOffSettings> {
     const started = Date.now();
     let originalState = this.powerState.get(contextId) ?? false;
 
+    // ensureServices and resolveTarget both reach the network and can throw
+    // (auth failure, rate limit, DNS). They used to sit outside this try, so
+    // a throw escaped onKeyDown entirely — no alert, no log, nothing.
     try {
+      await this.services.ensureServices(apiKey);
+      const target = await this.services.resolveTarget(settings);
+
+      if (!target) {
+        // resolveTarget has already logged which of its five reasons applied.
+        streamDeck.logger.warn(
+          "Key press ignored: could not resolve the selected device or group",
+        );
+        await ev.action.showAlert();
+        return;
+      }
+
       let command: "on" | "off";
 
       if (operation === "toggle") {

--- a/src/backend/actions/shared/ActionServices.ts
+++ b/src/backend/actions/shared/ActionServices.ts
@@ -445,11 +445,37 @@ export class ActionServices {
     forceRefresh = false,
   ): Promise<DeviceTarget | null> {
     const target = this.parseTarget(settings);
-    if (!target) return null;
+    if (!target) {
+      // Every null return below ends as an unexplained warning triangle on
+      // the key, so each one says which of the five reasons it was. Without
+      // this the user (and we) cannot tell "device vanished from the account"
+      // from "the API call failed" from "settings never had a device".
+      streamDeck.logger?.warn(
+        "resolveTarget: no target in settings — nothing selected, or settings did not parse",
+        {
+          selectedDeviceId: settings.selectedDeviceId,
+          selectedGroupId: settings.selectedGroupId,
+        },
+      );
+      return null;
+    }
 
     if (target.type === "group" && target.groupId) {
-      if (!this.groupService) return null;
+      if (!this.groupService) {
+        streamDeck.logger?.warn(
+          "resolveTarget: group selected but groupService is not initialised",
+          { groupId: target.groupId },
+        );
+        return null;
+      }
       const group = await this.groupService.findGroupById(target.groupId);
+      if (!group) {
+        streamDeck.logger?.warn(
+          "resolveTarget: group not found in storage — it may have been deleted",
+          { groupId: target.groupId },
+        );
+        return null;
+      }
       if (group) {
         // Group members are deserialized from storage with default
         // state (`isOnline: true, isOn: false`). Hydrate each member
@@ -491,17 +517,43 @@ export class ActionServices {
       }
     }
 
-    if (
-      target.type === "light" &&
-      target.deviceId &&
-      target.model &&
-      this.deviceService
-    ) {
+    if (target.type === "light") {
+      if (!target.deviceId || !target.model || !this.deviceService) {
+        streamDeck.logger?.warn(
+          "resolveTarget: light selected but the target is incomplete",
+          {
+            hasDeviceId: Boolean(target.deviceId),
+            hasModel: Boolean(target.model),
+            hasDeviceService: Boolean(this.deviceService),
+          },
+        );
+        return null;
+      }
+
       // Use DeviceService with its built-in caching (15s TTL)
       const lights = await this.deviceService.discover(forceRefresh);
       const lightItem = lights.find(
         (l) => l.deviceId === target.deviceId && l.model === target.model,
       );
+
+      if (!lightItem) {
+        // The most likely real-world failure: discovery came back without
+        // the selected device. An empty list usually means the API call
+        // failed or was rate-limited rather than the device being gone, so
+        // report the two cases differently.
+        streamDeck.logger?.warn(
+          lights.length === 0
+            ? "resolveTarget: discovery returned no devices at all — likely an API error or rate limit, not a missing device"
+            : "resolveTarget: selected device not present in discovery results",
+          {
+            wantDeviceId: target.deviceId,
+            wantModel: target.model,
+            discoveredCount: lights.length,
+            discoveredModels: lights.slice(0, 20).map((l) => l.model),
+          },
+        );
+        return null;
+      }
 
       if (lightItem) {
         // Convert LightItem to domain Light entity using Light.create()

--- a/src/backend/actions/shared/ActionServices.ts
+++ b/src/backend/actions/shared/ActionServices.ts
@@ -447,9 +447,9 @@ export class ActionServices {
     const target = this.parseTarget(settings);
     if (!target) {
       // Every null return below ends as an unexplained warning triangle on
-      // the key, so each one says which of the five reasons it was. Without
-      // this the user (and we) cannot tell "device vanished from the account"
-      // from "the API call failed" from "settings never had a device".
+      // the key, so each one says which of the five reasons it was.
+      // Without it, a device missing from the account, a failed API call
+      // and settings that never held a device all look identical.
       streamDeck.logger?.warn(
         "resolveTarget: no target in settings — nothing selected, or settings did not parse",
         {

--- a/test/backend/actions/shared/resolveTarget-diagnostics.test.ts
+++ b/test/backend/actions/shared/resolveTarget-diagnostics.test.ts
@@ -1,0 +1,142 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { streamDeck } from "@elgato/streamdeck";
+import { ActionServices } from "../../../../src/backend/actions/shared/ActionServices";
+
+/**
+ * Issue #311: a user could not control their H619A lights and saw only a
+ * warning triangle on the key. resolveTarget can return null for five
+ * distinct reasons, and every one produced that identical silent triangle
+ * — leaving neither the user nor us able to tell which had happened.
+ *
+ * These tests pin the diagnostics rather than the control flow: each null
+ * path must say why. If someone later drops the logging, the symptom (an
+ * unexplained triangle) returns silently, so the assertions are on the log
+ * call, not only on the null return.
+ */
+
+/** Swap services on the private static _shared, restoring afterwards. */
+const installShared = (patch: Record<string, unknown>) => {
+  const shared = (
+    ActionServices as unknown as { _shared: Record<string, unknown> }
+  )._shared;
+  const original: Record<string, unknown> = {};
+  for (const key of Object.keys(patch)) {
+    original[key] = shared[key];
+    shared[key] = patch[key];
+  }
+  return () => {
+    for (const key of Object.keys(patch)) {
+      shared[key] = original[key];
+    }
+  };
+};
+
+describe("resolveTarget diagnostics (issue #311)", () => {
+  let services: ActionServices;
+  let restore: (() => void) | undefined;
+  const warn = streamDeck.logger.warn as ReturnType<typeof vi.fn>;
+
+  const warnedWith = (fragment: string) =>
+    warn.mock.calls.some((c) => String(c[0]).includes(fragment));
+  const contextFor = (fragment: string) =>
+    warn.mock.calls.find((c) => String(c[0]).includes(fragment))?.[1] as
+      | Record<string, unknown>
+      | undefined;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    services = new ActionServices();
+  });
+
+  afterEach(() => {
+    restore?.();
+    restore = undefined;
+  });
+
+  it("explains an empty selection instead of failing silently", async () => {
+    const target = await services.resolveTarget({} as never);
+
+    expect(target).toBeNull();
+    expect(warnedWith("no target in settings")).toBe(true);
+  });
+
+  it("distinguishes a failed discovery from a genuinely missing device", async () => {
+    // Discovery returning nothing almost always means the API call failed
+    // or was rate-limited — not that the user's light disappeared. Saying
+    // "device not found" there sends everyone down the wrong path.
+    restore = installShared({
+      deviceService: {
+        discover: vi.fn().mockResolvedValue([]),
+        getCachedLights: vi.fn().mockReturnValue(null),
+      },
+    });
+
+    const target = await services.resolveTarget({
+      selectedDeviceId: "dev-1|H619A",
+    } as never);
+
+    expect(target).toBeNull();
+    expect(warnedWith("no devices at all")).toBe(true);
+    expect(warnedWith("selected device not present")).toBe(false);
+  });
+
+  it("reports the wanted device and what discovery actually returned", async () => {
+    // The diagnostic that would have resolved #311 in one round trip:
+    // which model was asked for, versus which models came back.
+    restore = installShared({
+      deviceService: {
+        discover: vi.fn().mockResolvedValue([
+          {
+            deviceId: "other-1",
+            model: "H6001",
+            name: "Strip",
+            controllable: true,
+          },
+        ]),
+        getCachedLights: vi.fn().mockReturnValue(null),
+      },
+    });
+
+    const target = await services.resolveTarget({
+      selectedDeviceId: "dev-1|H619A",
+    } as never);
+
+    expect(target).toBeNull();
+    expect(warnedWith("selected device not present")).toBe(true);
+
+    const context = contextFor("selected device not present");
+    expect(context).toMatchObject({
+      wantDeviceId: "dev-1",
+      wantModel: "H619A",
+      discoveredCount: 1,
+    });
+    expect(context?.discoveredModels).toContain("H6001");
+  });
+
+  it("explains a group that is no longer in storage", async () => {
+    restore = installShared({
+      groupService: { findGroupById: vi.fn().mockResolvedValue(null) },
+    });
+
+    const target = await services.resolveTarget({
+      selectedDeviceId: "group:grp-1",
+    } as never);
+
+    expect(target).toBeNull();
+    expect(warnedWith("group not found in storage")).toBe(true);
+  });
+
+  it("explains a light target whose device service is unavailable", async () => {
+    restore = installShared({ deviceService: undefined });
+
+    const target = await services.resolveTarget({
+      selectedDeviceId: "dev-1|H619A",
+    } as never);
+
+    expect(target).toBeNull();
+    expect(warnedWith("target is incomplete")).toBe(true);
+    expect(contextFor("target is incomplete")).toMatchObject({
+      hasDeviceService: false,
+    });
+  });
+});


### PR DESCRIPTION
Follow-up to #311, where the reporter still cannot control their H619A lights on v2.7.13 and has nothing to go on but a warning triangle.

## Why v2.7.13 appeared to do nothing

The v2.7.13 fix was real — it removed the gate on Govee's unreliable `online` flag. But there is an **earlier** gate it did not touch, and that gate is silent.

`onKeyDown` bails with `showAlert()` when `resolveTarget` returns `null`. `resolveTarget` can return `null` for five distinct reasons:

- settings that do not parse
- a missing group service
- a group deleted from storage
- an incomplete light target
- **the selected device not appearing in discovery results**

All five produced the same wordless triangle. The reporter is most likely hitting the last one, downstream of where v2.7.13 changed anything — but neither they nor we could tell, because nothing was written down.

## What this changes

Each null path now says which one it was. The diagnostic that matters:

```
resolveTarget: selected device not present in discovery results
  { wantDeviceId: "dev-1", wantModel: "H619A",
    discoveredCount: 1, discoveredModels: ["H6001"] }
```

That one line separates a model-string mismatch from a device genuinely absent from the account.

An empty discovery list is reported as **"likely an API error or rate limit, not a missing device"**, because that is what it almost always is. Calling it "device not found" is what sends people down the wrong path.

It also moves `ensureServices` and `resolveTarget` inside the `try` in `OnOffAction`. Both reach the network and can throw; sitting outside the try meant an auth failure or rate limit escaped `onKeyDown` entirely — no alert, no log.

## This does not fix #311

Deliberately. It makes the next report from that user say what is actually wrong, in one round trip instead of another guess. Shipping a second speculative fix that also failed would cost more than a day's wait.

## Verification

- 639 tests pass, typecheck and lint clean
- Five new tests assert on the **log calls**, not just the null returns — the diagnostics are the feature, so that is what needs guarding
- Mutation-tested rather than trusted green: neutering one diagnostic fails exactly the two tests asserting it and no others

## Scope

`OnOffAction` only. Brightness, Color, Toggle and Scene share the same unlogged `if (!target)` exit and should follow once this shape proves useful in practice — no reason to touch a dozen files before we know it answers the question.