### PR TITLE
chore(release): plugin 2.7.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project are documented below. This project adheres t
 
 ---
 
+## [2.7.14] - 2026-07-19
+
+### Fixed
+
+- **Control failures now say why, instead of a bare warning triangle** ([#311](https://github.com/felixgeelhaar/govee-light-management/issues/311)). A follow-up to the v2.7.13 fix, which removed the unreliable online-flag gate but left an earlier, silent one in place: when the plugin could not resolve the selected device or group it showed a warning and logged nothing, so five distinct causes — unparseable settings, a missing group service, a group deleted from storage, an incomplete light target, and the selected device not appearing in discovery — were indistinguishable. Each cause is now logged with its own message, and the discovery-miss case prints the device that was requested alongside the models discovery actually returned, so a model-string mismatch or an intermittently incomplete device list is visible at a glance. An empty discovery result is reported as a probable API error or rate limit rather than a missing device. `ensureServices` and `resolveTarget` were also moved inside the On/Off action's try block, so a network or auth error during resolution surfaces an alert and a log instead of escaping silently.
+
+### Internal
+
+- Added regression tests asserting each `resolveTarget` failure path logs its specific cause (mutation-verified).
+
 ## [2.7.13] - 2026-07-06
 
 ### Fixed

--- a/com.felixgeelhaar.govee-light-management.sdPlugin/manifest.json
+++ b/com.felixgeelhaar.govee-light-management.sdPlugin/manifest.json
@@ -1,6 +1,6 @@
 {
   "Name": "Govee Light Management",
-  "Version": "2.7.13.0",
+  "Version": "2.7.14.0",
   "Author": "Felix Geelhaar",
   "URL": "https://github.com/felixgeelhaar/govee-light-management",
   "SupportURL": "https://github.com/felixgeelhaar/govee-light-management/issues",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "govee-light-management",
-  "version": "2.7.13",
+  "version": "2.7.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "govee-light-management",
-      "version": "2.7.13",
+      "version": "2.7.14",
       "license": "MIT",
       "dependencies": {
         "@elgato/streamdeck": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "govee-light-management",
-  "version": "2.7.13",
+  "version": "2.7.14",
   "description": "Enterprise-grade Stream Deck plugin for managing Govee lights with advanced group functionality",
   "main": "com.felixgeelhaar.govee-light-management.sdPlugin/bin/plugin.js",
   "scripts": {


### PR DESCRIPTION
Version bump for the #311 diagnostics follow-up (merged in #331).

Bumps 2.7.13 → 2.7.14 across package.json, package-lock.json, and manifest.json, and adds the CHANGELOG entry.

2.7.14 makes control failures diagnosable: each of the five `resolveTarget` null paths now logs its specific cause, the discovery-miss case prints the requested device against what discovery returned, and On/Off resolution runs inside the try block so a network or auth error surfaces instead of escaping silently.

Once merged, tagging `v2.7.14` on main triggers the release workflow (lint → test → build → validate → pack → GitHub release with the packed plugin).

https://claude.ai/code/session_01HaZ7cQhpA5bRCk48wvYMhW