### PR TITLE
chore(security): remediate six dependency advisories (1 critical, 5 high)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2467,6 +2467,18 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
     "node_modules/ajv": {
       "version": "8.18.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
@@ -2539,13 +2551,14 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.0.tgz",
-      "integrity": "sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==",
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.19.0.tgz",
+      "integrity": "sha512-ht/iuYZXEjFxLH/Hkezgd7m6JKlHHXEUSneaDz8uZe1Gj5QZtCnpyDsckvAiEnT89OEbCLmnte4R4sn7P0EKFw==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.16.0",
-        "form-data": "^4.0.5",
+        "form-data": "^4.0.6",
+        "https-proxy-agent": "^5.0.1",
         "proxy-from-env": "^2.1.0"
       }
     },
@@ -2567,9 +2580,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
-      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2765,7 +2778,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -3238,9 +3250,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "dev": true,
       "funding": [
         {
@@ -3588,6 +3600,19 @@
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
     },
     "node_modules/iconv-lite": {
       "version": "0.7.2",
@@ -4352,7 +4377,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/mute-stream": {
@@ -4366,9 +4390,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.15",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
-      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "version": "3.3.17",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
+      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
       "dev": true,
       "funding": [
         {
@@ -4598,9 +4622,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.16",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
-      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
       "dev": true,
       "funding": [
         {
@@ -4618,7 +4642,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.17",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -5100,9 +5124,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.16",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.16.tgz",
-      "integrity": "sha512-56adEpPMouktRlBLXiaYFFzZ/3+JXa8P9n7WbR+ibIjtviN55mEaOkiysCnPnWm+7kkui1Dn8J9l+g6zV8731w==",
+      "version": "7.5.22",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.22.tgz",
+      "integrity": "sha512-MFO/QzvtAOmJbkhOaCTvbGcFN9L9b+JunIsDwaKljSOdcLMea3NJ1k9Usz/rjdfSXTq4dfzfeS7W4p4YOAAHeA==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
@@ -5302,9 +5326,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
-      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
       "dev": true,
       "license": "MIT",
       "engines": {


### PR DESCRIPTION
# Pull Request

## Description

`npm audit` reported six open advisories in transitive dependencies — **one critical, five high** — none of them introduced by any recent change. All six had fixes available inside the semver ranges `package.json` already declares, so **`package-lock.json` is the only file that changes**: no manifest edit, no major bumps, nothing to re-pin.

| Package | Bump | Sev | Scope | Advisory |
|---|---|---|---|---|
| `tar` | 7.5.16 → 7.5.22 | **critical** | dev | PAX numeric path type confusion (process crash), plus decompression DoS, negative-entry infinite loop, NUL-byte uncaught exception, unbounded recursion in `mapHas`/`filesFilter` |
| `undici` | 7.28.0 → 7.29.0 | high | dev | Response desync via retry interceptor; cross-user disclosure via cache directives; CRLF injection; cookie injection |
| `axios` | 1.16.0 → 1.19.0 | high | **runtime** | Excessive recursion in `formDataToJSON` (DoS) |
| `postcss` | 8.5.16 → 8.5.26 | high | dev | Path traversal via `sourceMappingURL` auto-loading |
| `fast-uri` | 3.1.2 → 3.1.5 | high | dev | Host confusion via literal backslash authority delimiter |
| `brace-expansion` | 2.1.0 → 2.1.4 | high | dev | Exponential-time expansion DoS |

After: **`npm audit --audit-level=high` → `found 0 vulnerabilities`.**

## ⚠️ One of these is a runtime dependency

Five are dev-only and never reach users — verified absent from the built bundle.

**`axios` is not.** It is pulled in by `@felixgeelhaar/govee-api-client@3.3.10`, and it is bundled into `bin/plugin.js` (9 `AxiosError` occurrences in the shipped output). It is the HTTP client behind **every Govee API call** — discovery, state reads, every command.

```
govee-light-management@2.7.14
└─┬ @felixgeelhaar/govee-api-client@3.3.10
  └── axios@1.19.0
```

1.16.0 → 1.19.0 is a minor bump inside the same major, and the advisory fix is narrow (recursion depth in `formDataToJSON`, a path this plugin does not use). Risk was low but not zero, and this is not a docs/CI change — so it was tested against real hardware rather than assumed. See the dogfood section below.

## 🎯 Hardware Dogfood

**Done.** This branch's build was linked under the real UUID and driven against live Govee hardware, specifically to exercise the axios bump — then the Marketplace build was restored.

All three axios code paths were exercised, and all three passed:

| Path | What ran | Result |
|---|---|---|
| **Read** | device discovery over the Govee cloud API | `device.discover {"total":6,"stale":false}` in 624 ms |
| **Write** | On/Off key issuing a power command to an H6056 ("Desk") | `onoff.toggle.request … "command":"on"` |
| **Read-back** | post-command state verification | `light.power.verify {"expected":true,"actual":true}` |

Toggled back afterwards (`expected:false/actual:false`) to leave the device as found. No errors or warnings in the plugin log, and no checksum failures on either the linked build or the restored Marketplace build (bundle hash `051960a2…`, byte-identical to the original).

Since `axios` is the HTTP client for every one of those calls, a successful discovery + command + verification round trip on 1.19.0 is direct evidence the bump is safe in the path this plugin actually uses.

What is verified off-hardware:

- `npm run type-check` — clean
- `npm run lint` — clean
- `npm test` — 639 passing, 46 files
- `npm run build` — Rollup bundle builds
- `npm audit --audit-level=high` — 0 vulnerabilities
- **warden's pre-push gate passed on this branch**, which still carries `main`'s *hard* audit step — so the gate that has been blocking every push now passes on its own merit rather than by being relaxed

## Type of Change

- [x] 🔧 Build/CI changes
- [x] 🏗️ Infrastructure changes
- [x] 🐛 Bug fix (the `axios` advisory affects shipped code)

## Related

Not a fix for an issue, but related to #334.

These are the advisories that made warden's pre-push audit step reject every push from every branch, `main` included — it ran as a hard gate while the CI it mirrors (`ci.yml:165`) runs the same command under `continue-on-error: true`.

**#334 relaxes that step to match CI. This PR removes the reason it was firing.** The two are independent — either alone unblocks pushing, and both are worth having: CI parity is correct regardless, and the advisories deserved fixing regardless.

## Note

GitHub Actions has not queued a run for this repository since 2026-08-05, across several pushes and a PR close/reopen cycle on #334. That is worth looking into separately — it likely means CI will not report on this PR either. Checks here were run locally instead, and warden's gate enforces the same set before anything leaves the machine.
