### PR TITLE
chore(dx): align relicta config with the actual release flow

### DIFF
--- a/.relicta.yaml
+++ b/.relicta.yaml
@@ -1,7 +1,25 @@
+# Relicta is a HELPER here, not the release driver.
+#
+# Releases are cut manually: a `chore(release): plugin X.Y.Z` PR bumps
+# package.json, package-lock.json and manifest.json, and merging it is followed
+# by an annotated `vX.Y.Z` tag. Pushing that tag is what triggers .github/
+# workflows/release.yml, which builds, packs and publishes the .streamDeckPlugin.
+#
+# Relicta is used for version inference (`relicta infer-version`) and changelog
+# drafting only. `gittag`, `gitpush` and the github plugin are therefore all
+# OFF: with them on, `relicta publish` would tag and push from a local checkout,
+# bypassing the release PR and firing release.yml behind your back, and the
+# github plugin would create a GitHub release that release.yml also creates.
+#
+# `versionfile` is deliberately EMPTY. It takes a single path, but this repo has
+# two version files in two formats — package.json (`2.7.15`) and manifest.json
+# (`2.7.15.0`, four-part, mandatory for Stream Deck). Pointing it at one would
+# bump half the repo and ship a manifest/package mismatch. Bump both by hand, or
+# see workflow.prereleasehook if you ever want this automated.
 ai:
     enabled: false
-    provider: openai
-    model: gpt-4
+    provider: ""
+    model: ""
     apikey: ""
     baseurl: ""
     apiversion: ""
@@ -25,26 +43,33 @@ changelog:
     productname: ""
     groupby: type
     template: ""
-    includecommithash: true
+    # The hand-written changelog carries no commit hashes and links every issue
+    # and PR it cites, so match that: hashes off, issue links on.
+    includecommithash: false
     includeauthor: false
     includedate: true
     linkcommits: false
-    linkissues: false
-    repositoryurl: ""
-    issueurl: ""
+    linkissues: true
+    repositoryurl: https://github.com/felixgeelhaar/govee-light-management
+    issueurl: https://github.com/felixgeelhaar/govee-light-management/issues
+    # `chore` and `ci` are NOT excluded — the Internal section of recent releases
+    # is exactly that work (workflow SHA pinning, the warden audit change).
     exclude:
-        - chore
-        - ci
         - docs
         - style
         - test
+    # Headings match keep-a-changelog and the sections actually used in
+    # 2.7.13-2.7.15: Fixed, Security, Internal, Changed.
     categories:
-        build: Build System
-        feat: Features
-        fix: Bug Fixes
-        perf: Performance Improvements
-        refactor: Code Refactoring
-        revert: Reverts
+        build: Internal
+        chore: Internal
+        ci: Internal
+        feat: Added
+        fix: Fixed
+        perf: Changed
+        refactor: Internal
+        revert: Changed
+        security: Security
 output:
     format: text
     color: true
@@ -54,8 +79,10 @@ output:
     loglevel: info
     pluginauditlog: ""
 plugins:
+    # Off: release.yml publishes the GitHub release on tag push. Enabling this
+    # would create a second, competing release.
     - name: github
-      enabled: true
+      enabled: false
       path: ""
       config:
         draft: false
@@ -66,8 +93,8 @@ plugins:
 versioning:
     strategy: conventional
     tagprefix: v
-    gittag: true
-    gitpush: true
+    gittag: false
+    gitpush: false
     gitsign: false
     prereleasesuffix: ""
     buildmetadata: ""
@@ -77,11 +104,10 @@ workflow:
     requireapproval: true
     allowedbranches:
         - main
-        - master
     requirecleanworkingtree: true
     requireuptodate: false
     dryrunbydefault: false
-    autocommitchangelog: true
-    changelogcommitmessage: 'chore(release): update changelog for ${version}'
+    autocommitchangelog: false
+    changelogcommitmessage: 'chore(release): plugin ${version}'
     prereleasehook: ""
     postreleasehook: ""


### PR DESCRIPTION
`.relicta.yaml` had drifted far from how this repo actually releases. Its last run was **v2.7.1 in May**, while 2.7.13, 2.7.14 and 2.7.15 all shipped as manual `chore(release)` PRs followed by an annotated tag.

## Why this mattered

Left alone it was a trap for whoever ran it next:

- `gittag: true` + `gitpush: true` — `relicta publish` would tag and push **from a local checkout**, bypassing the release PR and firing `release.yml` unannounced.
- The `github` plugin was enabled — it would create a GitHub release competing with the one `release.yml` already publishes on tag push.

## What changes

Relicta is scoped to what it is actually good for here — version inference and changelog drafting — with everything that could drive a release switched off (`gittag`, `gitpush`, the github plugin, `autocommitchangelog`).

Changelog settings corrected to match the hand-written `CHANGELOG.md`:

| Setting | Was | Now |
|---|---|---|
| `includecommithash` | `true` | `false` — the changelog carries no hashes |
| `linkissues` / `issueurl` | `false` / `""` | `true` / filled in — every entry links its issue |
| `exclude` | drops `chore`, `ci` | keeps them — the Internal section *is* that work |
| `categories` | no Security, no Internal | mapped to headings actually used |
| `changelogcommitmessage` | `update changelog for ${version}` | `chore(release): plugin ${version}` |
| `allowedbranches` | `main`, `master` | `main` |
| `ai` | `openai` / `gpt-4` | cleared (was disabled and unused) |

## `versionfile` stays empty, deliberately

It takes a **single** path, but this repo has two version files in two formats — `package.json` (`2.7.15`) and `manifest.json` (`2.7.15.0`, four-part, mandatory for Stream Deck). Pointing it at either bumps half the repo and ships a manifest/package mismatch. A header comment in the file records this and the reasoning for everything switched off, so the next person doesn't rediscover it the hard way.

## Verification

- `relicta plan --dry-run` parses the config and correctly infers `2.7.15` (patch), matching the release cut by hand.
- `relicta notes` now includes `chore` commits, confirming the `exclude` change is live.
- Local `.relicta/releases/` state — gitignored, untracked — held the stale v2.7.1 run and was blocking `notes` with `repository HEAD has changed since planning`. Cleared; `relicta status` is clean.

**Not exercised:** the `categories` mapping only renders during `publish`, which writes `CHANGELOG.md`. Since 2.7.15 is already cut, that path was not run — the mapping is configured but unverified end-to-end.

Config-only. No source, no build, no runtime effect.

https://claude.ai/code/session_011X7SqN7HphFrWv5nrg7BUV