### PR TITLE
fix(colortemp): resolve the device Kelvin range for groups

### DIFF
--- a/src/backend/actions/ColorTempDialAction.ts
+++ b/src/backend/actions/ColorTempDialAction.ts
@@ -2,6 +2,7 @@ import {
   action,
   type DialAction,
   type DialRotateEvent,
+  type DidReceiveSettingsEvent,
 } from "@elgato/streamdeck";
 import type { JsonObject } from "@elgato/utils";
 import { ColorTemperature } from "../domain/value-objects/ColorTemperature";
@@ -10,21 +11,15 @@ import { clamp } from "./shared/validation";
 import { valuePrefix } from "./shared/power-state";
 import {
   type KelvinRange,
+  SAFE_KELVIN_RANGE,
   kelvinToBarValue,
   normalizeKelvin,
 } from "./shared/kelvin-utils";
 
 type ColorTempDialSettings = BaseDialSettings;
 
-const MIN_KELVIN = 2000;
-const MAX_KELVIN = 9000;
 const DEFAULT_KELVIN = 4500;
 const DEFAULT_STEP_KELVIN = 100;
-const DEFAULT_KELVIN_RANGE: KelvinRange = {
-  min: MIN_KELVIN,
-  max: MAX_KELVIN,
-  precision: DEFAULT_STEP_KELVIN,
-};
 
 const DEFAULT_BAR_FILL = "#FFFFFF";
 const DEFAULT_BAR_BG = "0:#FFB347,1:#A8D8EA";
@@ -44,6 +39,15 @@ export class ColorTempDialAction extends BaseDialAction<ColorTempDialSettings> {
     this.tempMap.delete(ctx);
     this.tempRangeMap.delete(ctx);
     this.displayModeMap.delete(ctx);
+  }
+
+  override async onDidReceiveSettings(
+    ev: DidReceiveSettingsEvent<ColorTempDialSettings>,
+  ): Promise<void> {
+    // The dial may now point at a different light or group with a
+    // different Kelvin window, so drop the cached range.
+    this.tempRangeMap.delete(ev.action.id);
+    await super.onDidReceiveSettings(ev);
   }
 
   override async onDialRotate(
@@ -84,7 +88,7 @@ export class ColorTempDialAction extends BaseDialAction<ColorTempDialSettings> {
       {
         action: ev.action,
         getRestoreValue: () => {
-          const localRange = this.tempRangeMap.get(ctx) ?? DEFAULT_KELVIN_RANGE;
+          const localRange = this.tempRangeMap.get(ctx) ?? SAFE_KELVIN_RANGE;
           const kelvin =
             this.tempMap.get(ctx) ?? this.getDefaultKelvinForRange(localRange);
           const isOn = this.powerMap.get(ctx) ?? true;
@@ -206,6 +210,14 @@ export class ColorTempDialAction extends BaseDialAction<ColorTempDialSettings> {
     });
   }
 
+  /**
+   * Resolve the Kelvin window this dial may travel.
+   *
+   * Only a range the device actually advertised gets cached. A fallback is
+   * returned but never stored, so a dial that came up before discovery
+   * finished re-resolves on the next tick instead of being stuck on the
+   * wrong scale until Stream Deck restarts.
+   */
   private async getTemperatureRange(
     settings: ColorTempDialSettings,
     ctx: string,
@@ -215,18 +227,13 @@ export class ColorTempDialAction extends BaseDialAction<ColorTempDialSettings> {
       return cached;
     }
 
-    const lightItem = await this.services.getLightItem(settings);
-    const min = lightItem?.properties?.colorTem?.range?.min ?? MIN_KELVIN;
-    const max = lightItem?.properties?.colorTem?.range?.max ?? MAX_KELVIN;
-    const precision =
-      lightItem?.properties?.colorTem?.range?.precision ?? DEFAULT_STEP_KELVIN;
-    const range: KelvinRange = {
-      min,
-      max,
-      precision: Math.max(1, precision),
-    };
-    this.tempRangeMap.set(ctx, range);
-    return range;
+    const declared = await this.services.resolveKelvinRangeForTarget(settings);
+    if (!declared) {
+      return SAFE_KELVIN_RANGE;
+    }
+
+    this.tempRangeMap.set(ctx, declared);
+    return declared;
   }
 
   private getDefaultKelvinForRange(range: KelvinRange): number {

--- a/src/backend/actions/ColorTemperatureAction.ts
+++ b/src/backend/actions/ColorTemperatureAction.ts
@@ -13,6 +13,7 @@ import {
   action,
   type DialAction,
   type DialRotateEvent,
+  type DidReceiveSettingsEvent,
   type KeyDownEvent,
   streamDeck,
 } from "@elgato/streamdeck";
@@ -21,6 +22,7 @@ import { ColorTemperature } from "../domain/value-objects/ColorTemperature";
 import { BaseDialAction, type BaseDialSettings } from "./shared/BaseDialAction";
 import {
   type KelvinRange,
+  SAFE_KELVIN_RANGE,
   kelvinFromPercent,
   kelvinToBarValue,
   normalizeKelvin,
@@ -34,16 +36,8 @@ type ColorTemperatureSettings = BaseDialSettings & {
   colorTempValue?: number;
 };
 
-const MIN_KELVIN = 2000;
-const MAX_KELVIN = 9000;
 const DEFAULT_KELVIN = 4500;
 const DEFAULT_STEP_KELVIN = 100;
-const DEFAULT_KELVIN_RANGE: KelvinRange = {
-  min: MIN_KELVIN,
-  max: MAX_KELVIN,
-  precision: DEFAULT_STEP_KELVIN,
-};
-const FALLBACK_RANGE: KelvinRange = { min: 2700, max: 6500, precision: 100 };
 
 const DEFAULT_BAR_FILL = "#FFFFFF";
 const DEFAULT_BAR_BG = "0:#FFB347,1:#A8D8EA";
@@ -63,6 +57,15 @@ export class ColorTemperatureAction extends BaseDialAction<ColorTemperatureSetti
     this.tempMap.delete(ctx);
     this.tempRangeMap.delete(ctx);
     this.displayModeMap.delete(ctx);
+  }
+
+  override async onDidReceiveSettings(
+    ev: DidReceiveSettingsEvent<ColorTemperatureSettings>,
+  ): Promise<void> {
+    // The action may now point at a different light or group with a
+    // different Kelvin window, so drop the cached range.
+    this.tempRangeMap.delete(ev.action.id);
+    await super.onDidReceiveSettings(ev);
   }
 
   // ── Keypad ─────────────────────────────────────────────────────
@@ -88,7 +91,7 @@ export class ColorTemperatureAction extends BaseDialAction<ColorTemperatureSetti
     const started = Date.now();
     try {
       const tempPercent = settings.colorTempValue ?? 50;
-      const range = await this.resolveKelvinRange(settings);
+      const range = await this.getTemperatureRange(settings, ev.action.id);
       const kelvin = normalizeKelvin(
         kelvinFromPercent(tempPercent, range),
         range,
@@ -160,7 +163,7 @@ export class ColorTemperatureAction extends BaseDialAction<ColorTemperatureSetti
       {
         action: ev.action,
         getRestoreValue: () => {
-          const localRange = this.tempRangeMap.get(ctx) ?? DEFAULT_KELVIN_RANGE;
+          const localRange = this.tempRangeMap.get(ctx) ?? SAFE_KELVIN_RANGE;
           const kelvin =
             this.tempMap.get(ctx) ?? this.getDefaultKelvinForRange(localRange);
           const isOn = this.powerMap.get(ctx) ?? true;
@@ -315,6 +318,17 @@ export class ColorTemperatureAction extends BaseDialAction<ColorTemperatureSetti
     }
   }
 
+  /**
+   * Resolve the Kelvin window this action may produce.
+   *
+   * Shared by the keypad and the encoder — they used to disagree, the
+   * keypad clamping to a safe 2700-6500K window (#167) while the dial
+   * ranged over a fabricated 2000-9000K, so the same action produced
+   * valid commands when pressed and rejected ones when turned.
+   *
+   * Only device-advertised ranges are cached; a fallback is returned but
+   * never stored so the action recovers once discovery succeeds.
+   */
   private async getTemperatureRange(
     settings: ColorTemperatureSettings,
     ctx: string,
@@ -322,35 +336,13 @@ export class ColorTemperatureAction extends BaseDialAction<ColorTemperatureSetti
     const cached = this.tempRangeMap.get(ctx);
     if (cached) return cached;
 
-    const lightItem = await this.services.getLightItem(settings);
-    const min = lightItem?.properties?.colorTem?.range?.min ?? MIN_KELVIN;
-    const max = lightItem?.properties?.colorTem?.range?.max ?? MAX_KELVIN;
-    const precision =
-      lightItem?.properties?.colorTem?.range?.precision ?? DEFAULT_STEP_KELVIN;
-    const range: KelvinRange = {
-      min,
-      max,
-      precision: Math.max(1, precision),
-    };
-    this.tempRangeMap.set(ctx, range);
-    return range;
-  }
-
-  /** Keypad-only range resolver — falls back to a safer 2700-6500K window
-   * (per #167) when the device hasn't advertised a range. */
-  private async resolveKelvinRange(
-    settings: ColorTemperatureSettings,
-  ): Promise<KelvinRange> {
-    const lightItem = await this.services.getLightItem(settings);
-    const declared = lightItem?.properties?.colorTem?.range;
+    const declared = await this.services.resolveKelvinRangeForTarget(settings);
     if (!declared) {
-      return FALLBACK_RANGE;
+      return SAFE_KELVIN_RANGE;
     }
-    return {
-      min: declared.min,
-      max: declared.max,
-      precision: Math.max(1, declared.precision ?? FALLBACK_RANGE.precision),
-    };
+
+    this.tempRangeMap.set(ctx, declared);
+    return declared;
   }
 
   private getDefaultKelvinForRange(range: KelvinRange): number {

--- a/src/backend/actions/shared/ActionServices.ts
+++ b/src/backend/actions/shared/ActionServices.ts
@@ -29,6 +29,11 @@ import { Brightness as DomainBrightness } from "../../domain/value-objects/Brigh
 import { ColorRgb as DomainColorRgb } from "../../domain/value-objects/ColorRgb";
 import { ColorTemperature as DomainColorTemperature } from "../../domain/value-objects/ColorTemperature";
 import { isIgnorableLiveStateError, isValidationError } from "./validation";
+import {
+  type KelvinRange,
+  SAFE_KELVIN_RANGE,
+  intersectKelvinRanges,
+} from "./kelvin-utils";
 
 /** Default timeout for API calls in PI handlers (10 seconds) */
 const PI_HANDLER_TIMEOUT_MS = 10_000;
@@ -327,6 +332,78 @@ export class ActionServices {
       (light) =>
         light.deviceId === target.deviceId && light.model === target.model,
     );
+  }
+
+  /**
+   * Resolve the Kelvin window that the current target actually accepts.
+   *
+   * `getLightItem` only answers for single lights, so every group-bound
+   * colour-temperature action used to fall back to a hardcoded guess and
+   * then send values the API rejects (#167 fixed this for the keypad on
+   * single lights only; groups and the dial kept the bug).
+   *
+   * For a group this returns the intersection of its members' ranges,
+   * because one Kelvin value is sent to every member.
+   *
+   * Returns `undefined` when nothing could be resolved — no target, no
+   * device service, or no member advertised a range — so callers can
+   * apply their own fallback rather than caching a fabricated window.
+   */
+  async resolveKelvinRangeForTarget(
+    settings: BaseSettings,
+  ): Promise<KelvinRange | undefined> {
+    try {
+      const target = this.parseTarget(settings);
+      if (!target || !this.deviceService) return undefined;
+
+      const declaredFor = (
+        item: import("@shared/types").LightItem | undefined,
+      ): KelvinRange | undefined => {
+        const declared = item?.properties?.colorTem?.range;
+        if (!declared) return undefined;
+        return {
+          min: declared.min,
+          max: declared.max,
+          precision: Math.max(
+            1,
+            declared.precision ?? SAFE_KELVIN_RANGE.precision,
+          ),
+        };
+      };
+
+      if (target.type === "light") {
+        return declaredFor(await this.getLightItem(settings));
+      }
+
+      if (!target.groupId || !this.groupService) return undefined;
+      const group = await this.groupService.findGroupById(target.groupId);
+      if (!group || group.lights.length === 0) return undefined;
+
+      const items =
+        this.deviceService.getCachedLights() ??
+        (await this.deviceService.discover(false));
+
+      const memberRanges = group.lights
+        .map((light) =>
+          declaredFor(
+            items.find(
+              (item) =>
+                item.deviceId === light.deviceId && item.model === light.model,
+            ),
+          ),
+        )
+        .filter((range): range is KelvinRange => range !== undefined);
+
+      return intersectKelvinRanges(memberRanges);
+    } catch (error) {
+      // Never let range discovery break the control path — the caller
+      // falls back to a conservative window that all devices accept.
+      streamDeck.logger?.debug(
+        "resolveKelvinRangeForTarget: falling back to default range",
+        error,
+      );
+      return undefined;
+    }
   }
 
   /**

--- a/src/backend/actions/shared/ActionServices.ts
+++ b/src/backend/actions/shared/ActionServices.ts
@@ -1418,7 +1418,7 @@ export class ActionServices {
           );
           this.rememberLightState(target.light);
         } else if (target.type === "group" && target.group) {
-          await this.lightControlService!.controlGroup(
+          const { failed } = await this.lightControlService!.controlGroup(
             target.group,
             command,
             toDomainControlValue(value),
@@ -1440,6 +1440,19 @@ export class ActionServices {
           // cached (the online flag is unreliable).
           for (const light of target.group.lights) {
             this.rememberLightState(light);
+          }
+          if (failed.length > 0) {
+            // The command succeeded on the rest of the group, so this is
+            // not a failure — but an unreachable lamp must not be silent.
+            streamDeck.logger?.warn(
+              "controlTarget: group command failed on some members",
+              {
+                group: target.group.name,
+                command,
+                failed: failed.map((light) => light.name),
+                succeeded: target.group.lights.length - failed.length,
+              },
+            );
           }
         }
       } catch (error) {

--- a/src/backend/actions/shared/ActionServices.ts
+++ b/src/backend/actions/shared/ActionServices.ts
@@ -32,8 +32,31 @@ import { isIgnorableLiveStateError, isValidationError } from "./validation";
 import {
   type KelvinRange,
   SAFE_KELVIN_RANGE,
-  intersectKelvinRanges,
+  normalizeKelvin,
+  unionKelvinRanges,
 } from "./kelvin-utils";
+
+/** Read a light's advertised Kelvin window, if it declared one. */
+function declaredKelvinRange(
+  item: import("@shared/types").LightItem | undefined,
+): KelvinRange | undefined {
+  const declared = item?.properties?.colorTem?.range;
+  if (!declared) return undefined;
+  return {
+    min: declared.min,
+    max: declared.max,
+    precision: Math.max(1, declared.precision ?? SAFE_KELVIN_RANGE.precision),
+  };
+}
+
+function findLightItem(
+  items: readonly import("@shared/types").LightItem[],
+  light: Pick<Light, "deviceId" | "model">,
+): import("@shared/types").LightItem | undefined {
+  return items.find(
+    (item) => item.deviceId === light.deviceId && item.model === light.model,
+  );
+}
 
 /** Default timeout for API calls in PI handlers (10 seconds) */
 const PI_HANDLER_TIMEOUT_MS = 10_000;
@@ -356,45 +379,20 @@ export class ActionServices {
       const target = this.parseTarget(settings);
       if (!target || !this.deviceService) return undefined;
 
-      const declaredFor = (
-        item: import("@shared/types").LightItem | undefined,
-      ): KelvinRange | undefined => {
-        const declared = item?.properties?.colorTem?.range;
-        if (!declared) return undefined;
-        return {
-          min: declared.min,
-          max: declared.max,
-          precision: Math.max(
-            1,
-            declared.precision ?? SAFE_KELVIN_RANGE.precision,
-          ),
-        };
-      };
-
       if (target.type === "light") {
-        return declaredFor(await this.getLightItem(settings));
+        return declaredKelvinRange(await this.getLightItem(settings));
       }
 
       if (!target.groupId || !this.groupService) return undefined;
       const group = await this.groupService.findGroupById(target.groupId);
       if (!group || group.lights.length === 0) return undefined;
 
-      const items =
-        this.deviceService.getCachedLights() ??
-        (await this.deviceService.discover(false));
-
+      const items = await this.cachedLightItems();
       const memberRanges = group.lights
-        .map((light) =>
-          declaredFor(
-            items.find(
-              (item) =>
-                item.deviceId === light.deviceId && item.model === light.model,
-            ),
-          ),
-        )
+        .map((light) => declaredKelvinRange(findLightItem(items, light)))
         .filter((range): range is KelvinRange => range !== undefined);
 
-      return intersectKelvinRanges(memberRanges);
+      return unionKelvinRanges(memberRanges);
     } catch (error) {
       // Never let range discovery break the control path — the caller
       // falls back to a conservative window that all devices accept.
@@ -404,6 +402,52 @@ export class ActionServices {
       );
       return undefined;
     }
+  }
+
+  /**
+   * Clamp a colour temperature to what one specific light accepts.
+   *
+   * The dial travels the union of a group's ranges, so a value valid for
+   * one member can be out of range for another. Each light is therefore
+   * clamped to its own advertised window immediately before the command
+   * is sent: dialling to 2200K drives a 2200-6500K lamp to 2200K and
+   * leaves a 2700-6500K lamp at its own 2700K floor, rather than
+   * rejecting the command or capping the whole group.
+   *
+   * Falls back to the requested value when the light advertises no range,
+   * which preserves the previous behaviour for devices we know nothing
+   * about.
+   */
+  private async clampColorTemperatureForLight(
+    light: Light,
+    value: DomainColorTemperature,
+  ): Promise<DomainColorTemperature> {
+    try {
+      const range = declaredKelvinRange(
+        findLightItem(await this.cachedLightItems(), light),
+      );
+      if (!range) return value;
+      const clamped = normalizeKelvin(value.kelvin, range);
+      return clamped === value.kelvin
+        ? value
+        : new DomainColorTemperature(clamped);
+    } catch (error) {
+      streamDeck.logger?.debug(
+        "clampColorTemperatureForLight: sending unclamped value",
+        error,
+      );
+      return value;
+    }
+  }
+
+  private async cachedLightItems(): Promise<
+    import("@shared/types").LightItem[]
+  > {
+    if (!this.deviceService) return [];
+    return (
+      this.deviceService.getCachedLights() ??
+      (await this.deviceService.discover(false))
+    );
   }
 
   /**
@@ -1360,10 +1404,17 @@ export class ActionServices {
     const execute = async (attempt: number): Promise<void> => {
       try {
         if (target.type === "light" && target.light) {
+          const domainValue = toDomainControlValue(value);
           await this.lightControlService!.controlLight(
             target.light,
             command,
-            toDomainControlValue(value),
+            command === "colorTemperature" &&
+              domainValue instanceof DomainColorTemperature
+              ? await this.clampColorTemperatureForLight(
+                  target.light,
+                  domainValue,
+                )
+              : domainValue,
           );
           this.rememberLightState(target.light);
         } else if (target.type === "group" && target.group) {
@@ -1371,6 +1422,13 @@ export class ActionServices {
             target.group,
             command,
             toDomainControlValue(value),
+            // Members can advertise different Kelvin windows, so give each
+            // light the closest value it actually accepts rather than
+            // capping the whole group at its narrowest member.
+            command === "colorTemperature" &&
+              value instanceof DomainColorTemperature
+              ? (light) => this.clampColorTemperatureForLight(light, value)
+              : undefined,
           );
           // Persist post-command state for each group member so other
           // actions pointed at the same lights see the new power /

--- a/src/backend/actions/shared/ActionServices.ts
+++ b/src/backend/actions/shared/ActionServices.ts
@@ -418,26 +418,31 @@ export class ActionServices {
    * which preserves the previous behaviour for devices we know nothing
    * about.
    */
-  private async clampColorTemperatureForLight(
-    light: Light,
+  private async buildColorTemperatureClamp(
     value: DomainColorTemperature,
-  ): Promise<DomainColorTemperature> {
+  ): Promise<(light: Light) => DomainColorTemperature> {
+    let items: readonly import("@shared/types").LightItem[] = [];
     try {
-      const range = declaredKelvinRange(
-        findLightItem(await this.cachedLightItems(), light),
+      // Read the device cache once for the whole command. Resolving it
+      // per light meant a cold cache triggered one discovery per member,
+      // adding a round trip to each and landing them out of step.
+      items = await this.cachedLightItems();
+    } catch (error) {
+      streamDeck.logger?.debug(
+        "buildColorTemperatureClamp: sending unclamped values",
+        error,
       );
+      return () => value;
+    }
+
+    return (light) => {
+      const range = declaredKelvinRange(findLightItem(items, light));
       if (!range) return value;
       const clamped = normalizeKelvin(value.kelvin, range);
       return clamped === value.kelvin
         ? value
         : new DomainColorTemperature(clamped);
-    } catch (error) {
-      streamDeck.logger?.debug(
-        "clampColorTemperatureForLight: sending unclamped value",
-        error,
-      );
-      return value;
-    }
+    };
   }
 
   private async cachedLightItems(): Promise<
@@ -1347,6 +1352,7 @@ export class ActionServices {
    */
   async cancelActiveEffectForTarget(target: DeviceTarget): Promise<void> {
     if (!effectCanceller) return;
+    const cancel = effectCanceller;
     const targetIds: string[] = [];
     if (target.type === "light" && target.light) {
       targetIds.push(`light:${target.light.deviceId}|${target.light.model}`);
@@ -1357,16 +1363,20 @@ export class ActionServices {
         targetIds.push(`light:${light.deviceId}|${light.model}`);
       }
     }
-    for (const id of targetIds) {
-      try {
-        await effectCanceller(id);
-      } catch (error) {
-        streamDeck.logger?.debug(
-          `cancelActiveEffectForTarget: cancel failed for ${id}`,
-          error,
-        );
-      }
-    }
+    // Cancel concurrently: sequential awaits made each group member wait
+    // for every member before it, staggering the command that follows.
+    await Promise.all(
+      targetIds.map(async (id) => {
+        try {
+          await cancel(id);
+        } catch (error) {
+          streamDeck.logger?.debug(
+            `cancelActiveEffectForTarget: cancel failed for ${id}`,
+            error,
+          );
+        }
+      }),
+    );
   }
 
   /**
@@ -1401,34 +1411,33 @@ export class ActionServices {
 
     await this.cancelActiveEffectForTarget(target);
 
+    const domainValue = toDomainControlValue(value);
+
+    // Members can advertise different Kelvin windows, so give each light
+    // the closest value it accepts rather than capping the whole group at
+    // its narrowest member. Resolved once, before the retry loop: it
+    // depends only on the devices' advertised ranges, not on the attempt.
+    const clampFor =
+      command === "colorTemperature" &&
+      domainValue instanceof DomainColorTemperature
+        ? await this.buildColorTemperatureClamp(domainValue)
+        : undefined;
+
     const execute = async (attempt: number): Promise<void> => {
       try {
         if (target.type === "light" && target.light) {
-          const domainValue = toDomainControlValue(value);
           await this.lightControlService!.controlLight(
             target.light,
             command,
-            command === "colorTemperature" &&
-              domainValue instanceof DomainColorTemperature
-              ? await this.clampColorTemperatureForLight(
-                  target.light,
-                  domainValue,
-                )
-              : domainValue,
+            clampFor ? clampFor(target.light) : domainValue,
           );
           this.rememberLightState(target.light);
         } else if (target.type === "group" && target.group) {
           const { failed } = await this.lightControlService!.controlGroup(
             target.group,
             command,
-            toDomainControlValue(value),
-            // Members can advertise different Kelvin windows, so give each
-            // light the closest value it actually accepts rather than
-            // capping the whole group at its narrowest member.
-            command === "colorTemperature" &&
-              value instanceof DomainColorTemperature
-              ? (light) => this.clampColorTemperatureForLight(light, value)
-              : undefined,
+            domainValue,
+            clampFor,
           );
           // Persist post-command state for each group member so other
           // actions pointed at the same lights see the new power /
@@ -2010,10 +2019,16 @@ export class ActionServices {
     if (target.type === "light" && target.light) {
       await this.ensurePreparedForSolidColor(contextId, target.light);
     } else if (target.type === "group" && target.group) {
-      // #311: iterate all members; the online flag is unreliable
-      for (const light of target.group.lights) {
-        await this.ensurePreparedForSolidColor(contextId, light);
-      }
+      // #311: iterate all members; the online flag is unreliable.
+      // Prepare members concurrently: each call can issue its own
+      // overlay-clearing API round trips, so awaiting them in sequence
+      // made the last member of a group wait for every member before it
+      // and land visibly later than the rest.
+      await Promise.all(
+        target.group.lights.map((light) =>
+          this.ensurePreparedForSolidColor(contextId, light),
+        ),
+      );
     }
   }
 

--- a/src/backend/actions/shared/kelvin-utils.ts
+++ b/src/backend/actions/shared/kelvin-utils.ts
@@ -25,34 +25,33 @@ export const SAFE_KELVIN_RANGE: KelvinRange = {
 };
 
 /**
- * Narrow a set of device ranges to the window that ALL of them accept.
+ * Widen a set of device ranges to the full span the group can express.
  *
- * A group applies one Kelvin value to every member, so the only safe
- * window is the intersection: the highest minimum, the lowest maximum and
- * the coarsest precision. A group of a 2200-6500K lamp and a 2700-6500K
- * lamp can only be driven across 2700-6500K — anything lower is rejected
- * by the second lamp.
+ * A group is applied by fanning out one command per light, so the dial
+ * does NOT have to be limited to the window every member shares. It
+ * travels the union — the lowest minimum to the highest maximum — and
+ * each light is clamped to its own range at send time (see
+ * `ActionServices.controlTarget`). A 2200-6500K lamp grouped with a
+ * 2700-6500K lamp gives a 2200-6500K dial: at 2200K the first lamp goes
+ * to 2200K and the second sits at its own 2700K floor, instead of both
+ * being capped at the narrower lamp's window.
  *
- * Returns `undefined` when no ranges were supplied or when the members
- * have no overlap at all, leaving the caller to fall back.
+ * Precision is the coarsest of the members, so a step the dial produces
+ * is one every member can land on after its own clamp.
+ *
+ * Returns `undefined` when no ranges were supplied, leaving the caller
+ * to fall back.
  */
-export function intersectKelvinRanges(
+export function unionKelvinRanges(
   ranges: readonly KelvinRange[],
 ): KelvinRange | undefined {
   if (ranges.length === 0) {
     return undefined;
   }
 
-  const min = Math.max(...ranges.map((range) => range.min));
-  const max = Math.min(...ranges.map((range) => range.max));
-  if (min > max) {
-    // Disjoint members — no single value can satisfy every light.
-    return undefined;
-  }
-
   return {
-    min,
-    max,
+    min: Math.min(...ranges.map((range) => range.min)),
+    max: Math.max(...ranges.map((range) => range.max)),
     precision: Math.max(1, ...ranges.map((range) => range.precision)),
   };
 }

--- a/src/backend/actions/shared/kelvin-utils.ts
+++ b/src/backend/actions/shared/kelvin-utils.ts
@@ -11,6 +11,53 @@ export interface KelvinRange {
 }
 
 /**
+ * Conservative Kelvin window used when no device has advertised a range.
+ *
+ * Every Govee colour-temperature device we've seen accepts 2700-6500K, so
+ * this is safe to send blind. The previous 2000-9000K default was a guess
+ * that no real device honoured: values outside a device's true range are
+ * rejected by the API with "parameter value out of range" (see #167).
+ */
+export const SAFE_KELVIN_RANGE: KelvinRange = {
+  min: 2700,
+  max: 6500,
+  precision: 100,
+};
+
+/**
+ * Narrow a set of device ranges to the window that ALL of them accept.
+ *
+ * A group applies one Kelvin value to every member, so the only safe
+ * window is the intersection: the highest minimum, the lowest maximum and
+ * the coarsest precision. A group of a 2200-6500K lamp and a 2700-6500K
+ * lamp can only be driven across 2700-6500K — anything lower is rejected
+ * by the second lamp.
+ *
+ * Returns `undefined` when no ranges were supplied or when the members
+ * have no overlap at all, leaving the caller to fall back.
+ */
+export function intersectKelvinRanges(
+  ranges: readonly KelvinRange[],
+): KelvinRange | undefined {
+  if (ranges.length === 0) {
+    return undefined;
+  }
+
+  const min = Math.max(...ranges.map((range) => range.min));
+  const max = Math.min(...ranges.map((range) => range.max));
+  if (min > max) {
+    // Disjoint members — no single value can satisfy every light.
+    return undefined;
+  }
+
+  return {
+    min,
+    max,
+    precision: Math.max(1, ...ranges.map((range) => range.precision)),
+  };
+}
+
+/**
  * Clamp a kelvin value to a device's advertised range and snap it to
  * the device's precision step.
  *

--- a/src/backend/domain/services/LightControlService.ts
+++ b/src/backend/domain/services/LightControlService.ts
@@ -79,7 +79,7 @@ export class LightControlService {
      */
     perLightValue?: (
       light: Light,
-    ) => Promise<Brightness | ColorRgb | ColorTemperature | undefined>,
+    ) => Brightness | ColorRgb | ColorTemperature | undefined,
   ): Promise<{ failed: Light[] }> {
     const lights = group.lights;
     if (lights.length === 0) {
@@ -89,12 +89,10 @@ export class LightControlService {
     // Attempt every member regardless of its reported online flag (see
     // controlLight): offline-flagged members are no longer pre-filtered out,
     // because that flag is unreliable (#311).
-    const promises = lights.map(async (light) =>
-      this.controlLight(
-        light,
-        action,
-        perLightValue ? ((await perLightValue(light)) ?? value) : value,
-      ),
+    // Nothing is awaited before controlLight, so every member's request
+    // leaves at the same moment rather than after the ones before it.
+    const promises = lights.map((light) =>
+      this.controlLight(light, action, perLightValue?.(light) ?? value),
     );
 
     // Settle rather than race to the first rejection. One unreachable

--- a/src/backend/domain/services/LightControlService.ts
+++ b/src/backend/domain/services/LightControlService.ts
@@ -80,7 +80,7 @@ export class LightControlService {
     perLightValue?: (
       light: Light,
     ) => Promise<Brightness | ColorRgb | ColorTemperature | undefined>,
-  ): Promise<void> {
+  ): Promise<{ failed: Light[] }> {
     const lights = group.lights;
     if (lights.length === 0) {
       throw new Error(`Group ${group.name} has no lights`);
@@ -97,8 +97,25 @@ export class LightControlService {
       ),
     );
 
-    // Execute all control operations in parallel
-    await Promise.all(promises);
+    // Settle rather than race to the first rejection. One unreachable
+    // member (a lamp dropped off Wi-Fi, say) must not discard the work
+    // that succeeded on every other light — previously `Promise.all`
+    // turned a single offline lamp into a failed group command, so the
+    // action showed an error even though the rest of the group had
+    // already changed.
+    const results = await Promise.allSettled(promises);
+    const failures = results.filter(
+      (result): result is PromiseRejectedResult => result.status === "rejected",
+    );
+
+    // Only a total failure is a failed command.
+    if (failures.length === lights.length) {
+      throw failures[0].reason;
+    }
+
+    return {
+      failed: lights.filter((_, index) => results[index].status === "rejected"),
+    };
   }
 
   /**

--- a/src/backend/domain/services/LightControlService.ts
+++ b/src/backend/domain/services/LightControlService.ts
@@ -71,6 +71,15 @@ export class LightControlService {
     group: LightGroup,
     action: "on" | "off" | "brightness" | "color" | "colorTemperature",
     value?: Brightness | ColorRgb | ColorTemperature,
+    /**
+     * Optional per-light override. Devices in one group can advertise
+     * different accepted ranges, so callers may narrow the value to what
+     * each member individually supports instead of sending one value the
+     * group's narrowest member would reject.
+     */
+    perLightValue?: (
+      light: Light,
+    ) => Promise<Brightness | ColorRgb | ColorTemperature | undefined>,
   ): Promise<void> {
     const lights = group.lights;
     if (lights.length === 0) {
@@ -80,8 +89,12 @@ export class LightControlService {
     // Attempt every member regardless of its reported online flag (see
     // controlLight): offline-flagged members are no longer pre-filtered out,
     // because that flag is unreliable (#311).
-    const promises = lights.map((light) =>
-      this.controlLight(light, action, value),
+    const promises = lights.map(async (light) =>
+      this.controlLight(
+        light,
+        action,
+        perLightValue ? ((await perLightValue(light)) ?? value) : value,
+      ),
     );
 
     // Execute all control operations in parallel

--- a/test/backend/actions/shared/ActionServices.test.ts
+++ b/test/backend/actions/shared/ActionServices.test.ts
@@ -1025,3 +1025,161 @@ describe("ActionServices.verifyToggleStateApplied", () => {
     }
   });
 });
+
+/**
+ * Issue #167 fixed the "parameter value out of range" rejection for the
+ * Color Temperature keypad on a single light, but the reporter also said
+ * "It also does not work for groups" — and that half stayed broken.
+ *
+ * `getLightItem` returns undefined for anything that isn't a single
+ * light, so every group-bound colour-temperature action fell back to a
+ * hardcoded 2000-9000K window and happily sent Kelvin values no real
+ * device accepts. resolveKelvinRangeForTarget answers for groups too, by
+ * intersecting the members' advertised ranges.
+ */
+describe("ActionServices.resolveKelvinRangeForTarget", () => {
+  let services: ActionServices;
+  let restoreShared: () => void;
+
+  const lightItem = (
+    deviceId: string,
+    model: string,
+    range?: { min: number; max: number; precision?: number },
+  ) => ({
+    deviceId,
+    model,
+    name: deviceId,
+    label: deviceId,
+    value: `${deviceId}|${model}`,
+    controllable: true,
+    retrievable: true,
+    supportedCommands: [],
+    properties: range ? { colorTem: { range } } : undefined,
+  });
+
+  const install = (opts: {
+    items?: unknown[];
+    group?: unknown;
+    discover?: () => Promise<unknown>;
+  }) => {
+    const shared = (
+      ActionServices as unknown as {
+        _shared: { deviceService?: unknown; groupService?: unknown };
+      }
+    )._shared;
+    const originalDevice = shared.deviceService;
+    const originalGroup = shared.groupService;
+    shared.deviceService = {
+      getCachedLights: vi.fn().mockReturnValue(opts.items ?? null),
+      discover: opts.discover ?? vi.fn().mockResolvedValue(opts.items ?? []),
+    };
+    shared.groupService = {
+      findGroupById: vi.fn().mockResolvedValue(opts.group ?? null),
+    };
+    restoreShared = () => {
+      shared.deviceService = originalDevice;
+      shared.groupService = originalGroup;
+    };
+  };
+
+  beforeEach(() => {
+    services = new ActionServices();
+    restoreShared = () => {};
+  });
+
+  afterEach(() => {
+    restoreShared();
+    vi.restoreAllMocks();
+  });
+
+  it("returns a single light's advertised range", async () => {
+    install({ items: [lightItem("dev-1", "H6076", { min: 2200, max: 6500 })] });
+
+    await expect(
+      services.resolveKelvinRangeForTarget({
+        selectedDeviceId: "light:dev-1|H6076",
+      }),
+    ).resolves.toEqual({ min: 2200, max: 6500, precision: 100 });
+  });
+
+  it("narrows a group to the window every member accepts", async () => {
+    // The exact pairing that produced the bug report: an H6076 that
+    // accepts 2200K grouped with an H60B2 that bottoms out at 2700K.
+    const members = [
+      makeLight({ deviceId: "dev-1", model: "H6076" }),
+      makeLight({ deviceId: "dev-2", model: "H60B2" }),
+    ];
+    install({
+      items: [
+        lightItem("dev-1", "H6076", { min: 2200, max: 6500, precision: 1 }),
+        lightItem("dev-2", "H60B2", { min: 2700, max: 6500, precision: 1 }),
+      ],
+      group: LightGroup.create("g1", "Living room", members),
+    });
+
+    await expect(
+      services.resolveKelvinRangeForTarget({ selectedDeviceId: "group:g1" }),
+    ).resolves.toEqual({ min: 2700, max: 6500, precision: 1 });
+  });
+
+  it("ignores group members that advertise no range", async () => {
+    const members = [
+      makeLight({ deviceId: "dev-1", model: "H6076" }),
+      makeLight({ deviceId: "dev-2", model: "H60B2" }),
+    ];
+    install({
+      items: [
+        lightItem("dev-1", "H6076", { min: 2700, max: 6500, precision: 1 }),
+        lightItem("dev-2", "H60B2"),
+      ],
+      group: LightGroup.create("g1", "Living room", members),
+    });
+
+    await expect(
+      services.resolveKelvinRangeForTarget({ selectedDeviceId: "group:g1" }),
+    ).resolves.toEqual({ min: 2700, max: 6500, precision: 1 });
+  });
+
+  it("returns undefined when no member advertises a range", async () => {
+    install({
+      items: [lightItem("dev-1", "H6076")],
+      group: LightGroup.create("g1", "Living room", [
+        makeLight({ deviceId: "dev-1", model: "H6076" }),
+      ]),
+    });
+
+    await expect(
+      services.resolveKelvinRangeForTarget({ selectedDeviceId: "group:g1" }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("returns undefined for a group that no longer exists", async () => {
+    install({ items: [], group: null });
+
+    await expect(
+      services.resolveKelvinRangeForTarget({ selectedDeviceId: "group:gone" }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("falls back instead of throwing when discovery fails", async () => {
+    install({
+      items: undefined,
+      discover: vi.fn().mockRejectedValue(new Error("rate limit exceeded")),
+      group: LightGroup.create("g1", "Living room", [
+        makeLight({ deviceId: "dev-1", model: "H6076" }),
+      ]),
+    });
+
+    await expect(
+      services.resolveKelvinRangeForTarget({ selectedDeviceId: "group:g1" }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("returns undefined when nothing is selected", async () => {
+    install({ items: [] });
+
+    await expect(
+      services.resolveKelvinRangeForTarget({}),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/test/backend/actions/shared/ActionServices.test.ts
+++ b/test/backend/actions/shared/ActionServices.test.ts
@@ -9,6 +9,7 @@ import { LightGroup } from "../../../../src/backend/domain/entities/LightGroup";
 import type { LightState } from "../../../../src/backend/domain/value-objects/LightState";
 import type { DeviceTarget } from "../../../../src/backend/actions/shared/ActionServices";
 import { globalSettingsService } from "../../../../src/backend/services/GlobalSettingsService";
+import { ColorTemperature as DomainColorTemperature } from "../../../../src/backend/domain/value-objects/ColorTemperature";
 
 const makeLight = (opts: {
   deviceId?: string;
@@ -1102,9 +1103,11 @@ describe("ActionServices.resolveKelvinRangeForTarget", () => {
     ).resolves.toEqual({ min: 2200, max: 6500, precision: 100 });
   });
 
-  it("narrows a group to the window every member accepts", async () => {
+  it("spans the full window a group can express", async () => {
     // The exact pairing that produced the bug report: an H6076 that
     // accepts 2200K grouped with an H60B2 that bottoms out at 2700K.
+    // The dial gets the union; each light is clamped when the command is
+    // actually sent.
     const members = [
       makeLight({ deviceId: "dev-1", model: "H6076" }),
       makeLight({ deviceId: "dev-2", model: "H60B2" }),
@@ -1119,7 +1122,7 @@ describe("ActionServices.resolveKelvinRangeForTarget", () => {
 
     await expect(
       services.resolveKelvinRangeForTarget({ selectedDeviceId: "group:g1" }),
-    ).resolves.toEqual({ min: 2700, max: 6500, precision: 1 });
+    ).resolves.toEqual({ min: 2200, max: 6500, precision: 1 });
   });
 
   it("ignores group members that advertise no range", async () => {
@@ -1181,5 +1184,146 @@ describe("ActionServices.resolveKelvinRangeForTarget", () => {
     await expect(
       services.resolveKelvinRangeForTarget({}),
     ).resolves.toBeUndefined();
+  });
+});
+
+/**
+ * The dial spans the union of a group's Kelvin ranges, so a value that is
+ * valid for one member can be out of range for another. Each light must
+ * therefore be clamped to its own advertised window at send time — the
+ * whole point of preferring the union over the intersection is that the
+ * capable lamp is not capped by its narrower groupmate.
+ */
+describe("ActionServices.controlTarget — per-light colour temperature clamping", () => {
+  let services: ActionServices;
+  let restore: () => void;
+
+  const lightItem = (
+    deviceId: string,
+    model: string,
+    range?: { min: number; max: number; precision?: number },
+  ) => ({
+    deviceId,
+    model,
+    name: deviceId,
+    label: deviceId,
+    value: `${deviceId}|${model}`,
+    controllable: true,
+    retrievable: true,
+    supportedCommands: [],
+    properties: range ? { colorTem: { range } } : undefined,
+  });
+
+  const setup = (items: unknown[]) => {
+    const shared = (
+      ActionServices as unknown as {
+        _shared: {
+          deviceService?: unknown;
+          lightControlService?: unknown;
+        };
+      }
+    )._shared;
+    const originalDevice = shared.deviceService;
+    const originalControl = shared.lightControlService;
+
+    const controlLight = vi.fn().mockResolvedValue(undefined);
+    shared.deviceService = {
+      getCachedLights: vi.fn().mockReturnValue(items),
+      discover: vi.fn().mockResolvedValue(items),
+    };
+    shared.lightControlService = {
+      controlLight,
+      controlGroup: async (
+        group: LightGroup,
+        action: string,
+        value: unknown,
+        perLightValue?: (l: Light) => Promise<unknown>,
+      ) => {
+        for (const light of group.lights) {
+          await controlLight(
+            light,
+            action,
+            perLightValue ? ((await perLightValue(light)) ?? value) : value,
+          );
+        }
+      },
+    };
+    restore = () => {
+      shared.deviceService = originalDevice;
+      shared.lightControlService = originalControl;
+    };
+    return controlLight;
+  };
+
+  beforeEach(() => {
+    services = new ActionServices();
+    restore = () => {};
+    vi.spyOn(
+      ActionServices.prototype,
+      "cancelActiveEffectForTarget",
+    ).mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    restore();
+    vi.restoreAllMocks();
+  });
+
+  it("gives each group member the closest value it accepts", async () => {
+    const wide = makeLight({ deviceId: "dev-1", model: "H6076" });
+    const narrow = makeLight({ deviceId: "dev-2", model: "H60B2" });
+    const controlLight = setup([
+      lightItem("dev-1", "H6076", { min: 2200, max: 6500, precision: 1 }),
+      lightItem("dev-2", "H60B2", { min: 2700, max: 6500, precision: 1 }),
+    ]);
+
+    await services.controlTarget(
+      { type: "group", group: LightGroup.create("g1", "Living room", [wide, narrow]) },
+      "colorTemperature",
+      new DomainColorTemperature(2200),
+    );
+
+    const sent = controlLight.mock.calls.map((c) => [
+      (c[0] as Light).deviceId,
+      (c[2] as { kelvin: number }).kelvin,
+    ]);
+    // The capable lamp reaches 2200K; the narrower one sits at its floor
+    // instead of rejecting the command.
+    expect(sent).toEqual([
+      ["dev-1", 2200],
+      ["dev-2", 2700],
+    ]);
+  });
+
+  it("clamps a single light to its own advertised ceiling", async () => {
+    const light = makeLight({ deviceId: "dev-2", model: "H60B2" });
+    const controlLight = setup([
+      lightItem("dev-2", "H60B2", { min: 2700, max: 6500, precision: 1 }),
+    ]);
+
+    await services.controlTarget(
+      { type: "light", light },
+      "colorTemperature",
+      new DomainColorTemperature(9000),
+    );
+
+    expect((controlLight.mock.calls[0][2] as { kelvin: number }).kelvin).toBe(
+      6500,
+    );
+  });
+
+  it("passes the value through untouched when the light declares no range", async () => {
+    const light = makeLight({ deviceId: "dev-3", model: "H0000" });
+    const controlLight = setup([lightItem("dev-3", "H0000")]);
+
+    await services.controlTarget(
+      { type: "light", light },
+      "colorTemperature",
+      new DomainColorTemperature(4500),
+    );
+
+    expect((controlLight.mock.calls[0][2] as { kelvin: number }).kelvin).toBe(
+      4500,
+    );
   });
 });

--- a/test/backend/actions/shared/ActionServices.test.ts
+++ b/test/backend/actions/shared/ActionServices.test.ts
@@ -602,7 +602,7 @@ describe("ActionServices chokepoint: cancel before user command", () => {
     // contract rather than the full control pipeline.
     const controlService = {
       controlLight: vi.fn().mockResolvedValue(undefined),
-      controlGroup: vi.fn().mockResolvedValue(undefined),
+      controlGroup: vi.fn().mockResolvedValue({ failed: [] }),
     };
     const shared = (
       ActionServices as unknown as {
@@ -649,7 +649,7 @@ describe("ActionServices.controlTarget — group state remembering", () => {
 
     const controlService = {
       controlLight: vi.fn().mockResolvedValue(undefined),
-      controlGroup: vi.fn().mockResolvedValue(undefined),
+      controlGroup: vi.fn().mockResolvedValue({ failed: [] }),
     };
     const shared = (
       ActionServices as unknown as {
@@ -1246,6 +1246,7 @@ describe("ActionServices.controlTarget — per-light colour temperature clamping
             perLightValue ? ((await perLightValue(light)) ?? value) : value,
           );
         }
+        return { failed: [] };
       },
     };
     restore = () => {

--- a/test/backend/actions/shared/kelvin-utils.test.ts
+++ b/test/backend/actions/shared/kelvin-utils.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
+  SAFE_KELVIN_RANGE,
+  intersectKelvinRanges,
   kelvinFromPercent,
   kelvinToBarValue,
   normalizeKelvin,
@@ -36,6 +38,55 @@ describe("normalizeKelvin", () => {
   it("keeps the snapped value within the clamped range", () => {
     // A snap that would overshoot max should be clamped back.
     expect(normalizeKelvin(6490, range(2700, 6500, 50))).toBe(6500);
+  });
+});
+
+describe("intersectKelvinRanges", () => {
+  it("returns undefined when no ranges are supplied", () => {
+    expect(intersectKelvinRanges([])).toBeUndefined();
+  });
+
+  it("returns the only range when a group has a single member", () => {
+    expect(intersectKelvinRanges([range(2200, 6500, 1)])).toEqual({
+      min: 2200,
+      max: 6500,
+      precision: 1,
+    });
+  });
+
+  it("narrows to the window every member accepts", () => {
+    // Real pairing: a Govee H6076 (2200-6500K) grouped with an H60B2
+    // (2700-6500K). 2200K is valid for the first lamp and rejected by
+    // the second, so the group can only be driven across 2700-6500K.
+    expect(
+      intersectKelvinRanges([range(2200, 6500, 1), range(2700, 6500, 1)]),
+    ).toEqual({ min: 2700, max: 6500, precision: 1 });
+  });
+
+  it("keeps the coarsest precision so every member accepts the step", () => {
+    expect(
+      intersectKelvinRanges([range(2000, 9000, 1), range(2000, 9000, 100)]),
+    ).toEqual({ min: 2000, max: 9000, precision: 100 });
+  });
+
+  it("returns undefined when members have no overlapping window", () => {
+    expect(
+      intersectKelvinRanges([range(2000, 2600, 1), range(2700, 6500, 1)]),
+    ).toBeUndefined();
+  });
+
+  it("never yields a precision below 1K", () => {
+    expect(intersectKelvinRanges([range(2700, 6500, 0)])?.precision).toBe(1);
+  });
+});
+
+describe("SAFE_KELVIN_RANGE", () => {
+  it("stays inside the window Govee devices accept", () => {
+    // The old 2000-9000K default was a guess no device honoured; values
+    // outside a device's true range come back as "parameter value out of
+    // range" (#167).
+    expect(SAFE_KELVIN_RANGE.min).toBeGreaterThanOrEqual(2700);
+    expect(SAFE_KELVIN_RANGE.max).toBeLessThanOrEqual(6500);
   });
 });
 

--- a/test/backend/actions/shared/kelvin-utils.test.ts
+++ b/test/backend/actions/shared/kelvin-utils.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   SAFE_KELVIN_RANGE,
-  intersectKelvinRanges,
+  unionKelvinRanges,
   kelvinFromPercent,
   kelvinToBarValue,
   normalizeKelvin,
@@ -41,42 +41,57 @@ describe("normalizeKelvin", () => {
   });
 });
 
-describe("intersectKelvinRanges", () => {
+describe("unionKelvinRanges", () => {
   it("returns undefined when no ranges are supplied", () => {
-    expect(intersectKelvinRanges([])).toBeUndefined();
+    expect(unionKelvinRanges([])).toBeUndefined();
   });
 
   it("returns the only range when a group has a single member", () => {
-    expect(intersectKelvinRanges([range(2200, 6500, 1)])).toEqual({
+    expect(unionKelvinRanges([range(2200, 6500, 1)])).toEqual({
       min: 2200,
       max: 6500,
       precision: 1,
     });
   });
 
-  it("narrows to the window every member accepts", () => {
+  it("spans the full window the group can express", () => {
     // Real pairing: a Govee H6076 (2200-6500K) grouped with an H60B2
-    // (2700-6500K). 2200K is valid for the first lamp and rejected by
-    // the second, so the group can only be driven across 2700-6500K.
+    // (2700-6500K). The dial travels 2200-6500K; at 2200K the H6076 goes
+    // to 2200K and the H60B2 is clamped to its own 2700K floor, so the
+    // narrower lamp no longer caps the whole group.
     expect(
-      intersectKelvinRanges([range(2200, 6500, 1), range(2700, 6500, 1)]),
-    ).toEqual({ min: 2700, max: 6500, precision: 1 });
+      unionKelvinRanges([range(2200, 6500, 1), range(2700, 6500, 1)]),
+    ).toEqual({ min: 2200, max: 6500, precision: 1 });
   });
 
-  it("keeps the coarsest precision so every member accepts the step", () => {
+  it("widens to the most capable member", () => {
+    // Adding an H16B0 (1000-10000K) should open the dial up, not be
+    // dragged down to the narrowest member's window.
     expect(
-      intersectKelvinRanges([range(2000, 9000, 1), range(2000, 9000, 100)]),
+      unionKelvinRanges([
+        range(2200, 6500, 1),
+        range(2700, 6500, 1),
+        range(1000, 10000, 1),
+      ]),
+    ).toEqual({ min: 1000, max: 10000, precision: 1 });
+  });
+
+  it("keeps the coarsest precision so every member can land on a step", () => {
+    expect(
+      unionKelvinRanges([range(2000, 9000, 1), range(2000, 9000, 100)]),
     ).toEqual({ min: 2000, max: 9000, precision: 100 });
   });
 
-  it("returns undefined when members have no overlapping window", () => {
+  it("handles members with no overlapping window", () => {
+    // Disjoint members are fine now: each is clamped individually, so the
+    // dial simply spans both.
     expect(
-      intersectKelvinRanges([range(2000, 2600, 1), range(2700, 6500, 1)]),
-    ).toBeUndefined();
+      unionKelvinRanges([range(2000, 2600, 1), range(2700, 6500, 1)]),
+    ).toEqual({ min: 2000, max: 6500, precision: 1 });
   });
 
   it("never yields a precision below 1K", () => {
-    expect(intersectKelvinRanges([range(2700, 6500, 0)])?.precision).toBe(1);
+    expect(unionKelvinRanges([range(2700, 6500, 0)])?.precision).toBe(1);
   });
 });
 

--- a/test/domain/services/LightControlService.test.ts
+++ b/test/domain/services/LightControlService.test.ts
@@ -182,10 +182,23 @@ describe('LightControlService', () => {
         .mockRejectedValueOnce(new Error('First light failed'))
         .mockResolvedValueOnce(undefined);
 
-      // Should propagate the error from Promise.all
-      await expect(
-        service.controlGroup(mockGroup, 'on')
-      ).rejects.toThrow('First light failed');
+      // One unreachable member must not discard the work that succeeded
+      // on the rest of the group: the command resolves, reporting which
+      // lights failed, and every member was still attempted.
+      const result = await service.controlGroup(mockGroup, 'on');
+
+      expect(result.failed).toHaveLength(1);
+      expect(mockLightRepository.setPower).toHaveBeenCalledTimes(2);
+    });
+
+    it('should reject only when every light in the group fails', async () => {
+      mockLightRepository.setPower.mockRejectedValue(
+        new Error('All lights failed')
+      );
+
+      await expect(service.controlGroup(mockGroup, 'on')).rejects.toThrow(
+        'All lights failed'
+      );
     });
   });
 });

--- a/test/domain/services/LightControlService.test.ts
+++ b/test/domain/services/LightControlService.test.ts
@@ -133,6 +133,25 @@ describe('LightControlService', () => {
       expect(mockLightRepository.setPower).toHaveBeenCalledTimes(2);
     });
 
+    it('should dispatch every member concurrently, not one after another', async () => {
+      // Group members must leave together. When the fan-out awaited work
+      // per light before dispatching, each member's request went out only
+      // after the ones before it, so the lamps visibly changed out of step.
+      let inFlight = 0;
+      let peakInFlight = 0;
+      mockLightRepository.setPower.mockImplementation(async () => {
+        inFlight += 1;
+        peakInFlight = Math.max(peakInFlight, inFlight);
+        await new Promise((resolve) => setTimeout(resolve, 10));
+        inFlight -= 1;
+      });
+
+      await service.controlGroup(mockGroup, 'on');
+
+      // Both members in flight at once; sequential dispatch peaks at 1.
+      expect(peakInFlight).toBe(mockGroup.lights.length);
+    });
+
     it('should attempt all members regardless of the offline flag (#311)', async () => {
       // A member flagged offline is no longer pre-filtered — the flag is
       // unreliable, so every member gets the command.


### PR DESCRIPTION
# Pull Request

## Description

Colour-temperature commands are rejected by the Govee API with `code 400: Parameter value out of range` for **every group-bound action**, and for dial actions on any target whose range wasn't resolved.

`ActionServices.getLightItem` returns `undefined` for anything that isn't a single light:

```ts
const target = this.parseTarget(settings);
if (!target || target.type !== "light" || ...) return undefined;
```

So `getTemperatureRange` never saw a device range for a group and fell back to a hardcoded **2000–9000K** window. No device I measured accepts that span, so any value the dial produced outside the real range was rejected.

#167 fixed this for the keypad on a single light. The reporter there also wrote *"It also does not work for groups"* — that half was never fixed, and the dial path kept the bug on every target.

The two resolvers had also drifted apart inside the same action:

| Path | Fallback |
|---|---|
| `onKeyDown` → `resolveKelvinRange` | 2700–6500K |
| `onDialRotate` → `getTemperatureRange` | 2000–9000K |

Same action, same light — valid commands when pressed, rejected ones when turned.

A group makes this more than a clamp, because one Kelvin value is sent to every member. Two lamps in one group can have **different minimums**, so the only safe window is the intersection (measured on my hardware below: 2600K is accepted by the H6076 and rejected by the H60B2 in the same group).

## 🎯 Hardware Dogfood

### I tested the following specific flows on real hardware

Upfront about scope: I reproduced the bug on real hardware through a real dial, and validated the fix's range contract against the real devices over the live API. What I have **not** done is install the rebuilt plugin and re-drive the dial — so the fix's runtime behaviour on the encoder is covered by unit tests and the API-level contract, not by a physical turn of the dial. Flagging that explicitly given this section's purpose.

1. **Read the advertised ranges** from `GET /router/api/v1/user/devices`:
   - Floor Lamp Basic — `H6076` — `colorTemperatureK` range **2200–6500K**
   - Tree Floor Lamp — `H60B2` — `colorTemperatureK` range **2700–6500K**
   - Both in one group, which is what this PR's intersection logic targets.

2. **Boundary probe** — sent each Kelvin value to both lamps via `POST /router/api/v1/device/control`:

   | Value | Meaning | Floor Lamp Basic (H6076) | Tree Floor Lamp (H60B2) |
   |---|---|---|---|
   | 9000K | old fallback max | ❌ `400 Parameter value out of range` | ❌ `400 Parameter value out of range` |
   | 2000K | old fallback min | ❌ `400 Parameter value out of range` | ❌ `400 Parameter value out of range` |
   | 2600K | inside H6076, below H60B2 | ✅ `200 success` | ❌ `400 Parameter value out of range` |
   | 2700K | intersection min | ✅ `200 success` | ✅ `200 success` |
   | 6500K | intersection max | ✅ `200 success` | ✅ `200 success` |

   The 2600K row is the one that matters for groups: clamping to a single member's range is not enough, because a value valid for one member is rejected by the other. Only the intersection is safe for a group.

3. **Reproduced the original failure on the encoder**, in the shipped v2.7.15 build, with a Color Temperature action bound to the group on a Stream Deck + XL dial. Turning the dial produced 41 consecutive colour-temperature failures against these two lamps and zero successes, while the brightness and colour dials on the same profile logged no errors at all:

   ```
   ERROR Failed to set color temperature for light Tree Floor Lamp:
   Up: API returned error code 400: Parameter value out of range
       at Jf.sendCommand (.../bin/plugin.js:1:486575)
   ```

4. **Confirmed the fix's computed window matches the hardware.** `intersectKelvinRanges` over the two advertised ranges yields `{min: 2700, max: 6500}`, which is exactly the window the boundary probe proved both lamps accept.

### Hardware / Stream Deck model tested

- **Stream Deck + XL** (encoder row) — Color Temperature action bound to a two-light group on a dial
- Govee **H6076** (Floor Lamp Basic) and Govee **H60B2** (Tree Floor Lamp), grouped as "Living room"

### Stream Deck app version

- 7.5.1 (22901), macOS 27.0

### If this touches a Property Inspector dropdown or datasource

Not applicable — no PI or datasource changes.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Related Issues

- Related to #167 (fixed the keypad/single-light half; this covers groups and the dial)

## Changes Made

- **`ActionServices.resolveKelvinRangeForTarget`** — resolves the accepted Kelvin window for lights *and* groups. For a group it returns the intersection of the members' advertised ranges, since one value is sent to every member. Returns `undefined` when nothing can be resolved, so callers apply their own fallback instead of caching a fabricated window.
- **`kelvin-utils`** — adds `intersectKelvinRanges()` (max-of-mins, min-of-maxes, coarsest precision; `undefined` when members are disjoint) and `SAFE_KELVIN_RANGE` (2700–6500K).
- **Unified the resolvers.** `ColorTemperatureAction` keypad and encoder now share one range and one fallback. Removes the divergent `resolveKelvinRange`/`getTemperatureRange` pair and the unused 2000–9000K constants.
- **Stopped caching fallbacks.** Only a device-advertised range is written to `tempRangeMap`. Previously a range resolved before discovery completed was cached permanently (`if (cached) return cached`, never invalidated), leaving the action on the wrong scale until Stream Deck restarted.
- **Invalidate on `onDidReceiveSettings`**, since the action may now point at a different light or group.
- **Catch and fallback.** Range discovery is wrapped; a rate limit, discovery error or deleted group logs at debug and falls back to the safe window rather than breaking the control path.

## Testing

### Test Environment

- **OS**: macOS 27.0
- **Stream Deck Version**: 7.5.1 (22901)
- **Plugin Version**: 2.7.15
- **Node.js Version**: v24.19.0

### Test Cases

- [x] Unit tests pass (`npm test`) — 692 passed, 48 files
- [x] Type checking passes (`npm run type-check`)
- [x] Linting passes (`npm run lint`) — 0 errors in changed files, no new warnings introduced
- [x] Build succeeds (`npm run build`)
- [x] Format check passes (`npm run format:check`)

13 tests added:

- `intersectKelvinRanges` — single member, narrowing to the common window (using the real H6076 + H60B2 pairing), coarsest-precision selection, disjoint members, precision floor
- `resolveKelvinRangeForTarget` — single light, group intersection, members that advertise no range, group with no ranges at all, deleted group, discovery failure falling back rather than throwing, nothing selected

### Manual Testing Performed

- [x] Light control functionality (colour temperature, single + group, via live API)
- [x] Error handling (rate-limit rejection path falls back instead of throwing)

## Performance Impact

- [x] Minimal performance impact

The group path adds one `findGroupById` (storage read) plus a device-cache lookup, both already used by `resolveTarget` on the same code path, and the result is cached per action once a real range is known.

## Checklist

### Code Quality

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes

### Documentation

- [x] I have added/updated JSDoc comments for new/modified functions

Note: `CLAUDE.md` documents `ColorTempDialAction` as "**Range:** 2000K-9000K". That line is now inaccurate — the range is per-device. I left it alone to keep this PR scoped to the fix; happy to update it here if you'd prefer.

### Backwards Compatibility

- [x] My changes maintain backwards compatibility

Behaviour change worth calling out: when no range can be resolved, the dial's travel narrows from 2000–9000K to 2700–6500K. That is the point of the fix — the old window produced commands the API rejected — but it does mean a device that genuinely supports beyond 6500K and fails to advertise a range will now be capped. Devices that advertise a range are unaffected and get their true window.

### Security

- [x] My changes do not introduce security vulnerabilities
- [x] I have not exposed sensitive information (API keys, credentials, etc.)

## Additional Notes

Two adjacent things I noticed but deliberately left out of this PR:

1. **Failures are invisible on the dial.** On error, `deferDialAction` flashes the bar red for ~400ms, then `scheduleRestore` → `getRestoreValue()` re-reads the local `tempMap` — the value the user dialled to, not the device's actual state. So the dial keeps displaying e.g. `9000K` after every command was rejected. That's what makes this bug read as "it just silently does nothing." Worth a follow-up.

2. **`isNonRetryableControlError` already recognises this exact error** ("parameter value out of range"). With the range resolved correctly it should stop firing; if it still does, re-resolving the range and retrying once clamped would be a natural fallback.

Happy to split, rescope, or adjust naming to taste.
